### PR TITLE
Document fix for Windows long file path error

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 1. Download the [latest version](https://github.com/carson-katri/dream-textures/releases/tag/0.0.4) from the Releases tab.
 2. Install the addon in Blender's preferences window.
 3. Follow the steps in the 'Dream Textures' preferences window to install the necessary dependencies.
+   - _*Note for Windows users*_ - If you get an error when installing dependencies that looks similar to the one described [here](https://github.com/carson-katri/dream-textures/issues/13), your dependency file paths might be too long (can't be longer than 256 characters). You can solve it by telling Windows to allow long file paths in the registry:
+     1. Open up the Window registry (Start > Run > `regedit`)
+     2. Navigate to `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem`
+     3. Set `LongPathsEnabled` to `1`
 
 | Enter a prompt | Generate a unique texture in a few seconds |
 | -------------- | ------------------------------------------ |

--- a/help_section.py
+++ b/help_section.py
@@ -6,6 +6,7 @@ def register_section_props():
     for prop in [
         "err_deps_visible",
         "err_wrong_download",
+        "err_long_file_path",
         "err_crash",
         "err_silent_fail",
         "err_catchall",
@@ -48,6 +49,18 @@ def help_section(layout, context):
         steps=[
             "You most likely downloaded the source code, not the bundled addon.",
             "Go to the Releases sidebar tab on GitHub and download the file called 'dream_textures.zip'.",
+        ]
+    )
+
+    faq_box(
+        "err_long_file_path",
+        title="ERROR: No matching distribution found for basicsr>=1.4.2 ...",
+        steps=[
+            "You might have reached Windows' file path character limit.",
+            "1. Open up the Window registry (Start > Run > regedit)",
+            "2. Navigate to HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem",
+            "3. Set LongPathsEnabled to 1",
+            "You will need to restart your computer and re-install the dependencies.",
         ]
     )
 


### PR DESCRIPTION
Fixes #13.

Turns out `basicsr@1.4.2` fails to install for many Windows users because during its setup, `pytorch` (a sub dependency) fails to install. And `pytorch` fails because it can't find a certain file on disk (in this specific case, `learning_rate_adaption_op_test.test_learning_rate_adaption_op_normalization.zip`).

[Turns out](https://github.com/pytorch/pytorch/issues/23823#issuecomment-518410698) this is a known issue with `pytorch` and is actually caused by file paths being too long. Windows apparently maxes out around 260 characters, unless you specifically tell Windows to allow long paths.

You can do this by:

1. Open up the Window registry (Start > Run > `regedit`)
2. Navigate to `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem`
3. Set `LongPathsEnabled` to `1`

This PR adds a note describing this issue under the dependency installation section in the README & Troubleshooting section within the addon so that future Windows users don't get tripped up by this.

As a side note, I was wondering why Windows doesn't enable `LongPathsEnabled` by default - apparently some apps still do not support long paths, so allowing Windows to create long paths (eg. through file explorer) might create more problems for people who don't know what they're doing. Of course in this situation its worth the compromise!