### PR TITLE
Improved seed selector

### DIFF
--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -101,6 +101,7 @@ class DreamTexture(bpy.types.Operator):
                     if area.type == 'IMAGE_EDITOR':
                         area.spaces.active.image = image
                 scene.dream_textures_progress = 0
+                scene.dream_textures_prompt.seed = str(seed) # update property in case seed was sourced randomly or from hash
         
         def view_step(samples, step):
             step_progress(samples, step)
@@ -156,7 +157,7 @@ class DreamTexture(bpy.types.Operator):
                 # refinement steps per iteration
                 steps=scene.dream_textures_prompt.steps,
                 # seed for random number generator
-                seed=None if scene.dream_textures_prompt.seed == -1 else scene.dream_textures_prompt.seed,
+                seed=scene.dream_textures_prompt.get_seed(),
                 # width of image, in multiples of 64 (512)
                 width=scene.dream_textures_prompt.width,
                 # height of image, in multiples of 64 (512)

--- a/ui/panel.py
+++ b/ui/panel.py
@@ -59,7 +59,10 @@ def draw_panel(self, context):
     advanced_box_heading.label(text="Advanced Configuration")
     if scene.dream_textures_prompt.show_advanced:
         advanced_box.prop(scene.dream_textures_prompt, "full_precision")
-        advanced_box.prop(scene.dream_textures_prompt, "seed")
+        advanced_box.prop(scene.dream_textures_prompt, "random_seed")
+        seed_row = advanced_box.row()
+        seed_row.prop(scene.dream_textures_prompt, "seed")
+        seed_row.enabled = not scene.dream_textures_prompt.random_seed
         # advanced_box.prop(self, "iterations") # Disabled until supported by the addon.
         advanced_box.prop(scene.dream_textures_prompt, "steps")
         advanced_box.prop(scene.dream_textures_prompt, "cfgscale")


### PR DESCRIPTION
Replaced seed selection with a random seed bool and manual seed string properties. The string property will allow seeds to be anything within a 32-bit uint (which appears to be the limit from pytorch's internals pytorch_lighting/utilities/seed.py seed_everything()) and fixes #41.

![image](https://user-images.githubusercontent.com/47096043/191805015-eb5c0f09-2a9d-4bd7-9505-1eefa7b0366c.png)

If the seed cannot be parsed to an int it will get a seed based on its hash. After an image is generated the seed property will get updated with the random seed or hash so someone may easily disable random seed to tweak settings when a desired seed is found.