### PR TITLE
Fixed AttributeError with NoneType in context.area.regions

### DIFF
--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -78,10 +78,12 @@ class DreamTexture(bpy.types.Operator):
         scene = context.scene
 
         def step_progress_update(self, context):
-            for region in context.area.regions:
-                if region.type == "UI":
-                    region.tag_redraw()
+            if hasattr(context.area,"regions"):
+                for region in context.area.regions:
+                    if region.type == "UI":
+                        region.tag_redraw()
             return None
+
         bpy.types.Scene.dream_textures_progress = bpy.props.IntProperty(name="Progress", default=1, min=0, max=context.scene.dream_textures_prompt.steps + 1, update=step_progress_update)
 
         def image_writer(image, seed, upscaled=False):

--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -78,7 +78,7 @@ class DreamTexture(bpy.types.Operator):
         scene = context.scene
 
         def step_progress_update(self, context):
-            if hasattr(context.area,"regions"):
+            if hasattr(context.area, "regions"):
                 for region in context.area.regions:
                     if region.type == "UI":
                         region.tag_redraw()


### PR DESCRIPTION
I was getting this error in the System Console. This is a fix.
```
 for region in context.area.regions:
AttributeError: 'NoneType' object has no attribute 'regions'
```