### PR TITLE
Make Free Generator also empty cuda cache

### DIFF
--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -203,6 +203,11 @@ class ReleaseGenerator(bpy.types.Operator):
 
     def execute(self, context):
         global generator
+        if generator:
+            generator.model.cpu()
         generator = None
+        gc.collect()
+        import torch
+        torch.cuda.empty_cache()
         context.scene.dream_textures_progress = 0
         return {'FINISHED'}


### PR DESCRIPTION
I never noticed any VRAM releasing when activating Free Generator before making these changes.

`torch.cuda.empty_cache()` doesn't quite clear everything on its own and `generator.model.cpu()` seems to let it clear some more. Still had about 750MB of VRAM uncleared (according to `torch.cuda.memory_reserved()`) after that. I can't figure out how to clear the rest.

Unsure if `torch.cuda.empty_cache()` may error for a non-cuda system, someone else with appropriate hardware will have to test.

Not a perfect solution for #42, but it does seem to mostly do what it needs now.