### PR TITLE
Direct users who downloaded source to download release

### DIFF
--- a/generator_process.py
+++ b/generator_process.py
@@ -224,7 +224,7 @@ def main():
                 )
                 generator.load_model()
             except Exception as e:
-                writeException(True, str(e))
+                writeException(True, repr(e))
                 return
         writeInfo("Starting")
         
@@ -253,7 +253,7 @@ def main():
                         writeException(True, s) # consider all unknown exceptions to be fatal so the generator process is fully restarted next time
                         return
         except Exception as e:
-            writeException(True, str(e))
+            writeException(True, repr(e))
             return
         finally:
             sys.stderr = stderr

--- a/generator_process.py
+++ b/generator_process.py
@@ -154,11 +154,14 @@ def main():
         from omegaconf import OmegaConf
         from PIL import ImageOps
         from io import StringIO
+    except ModuleNotFoundError as e:
+        min_files = 10 # bump this up if more files get added to .python_dependencies in source
+                       # don't set too high so it can still pass info on indiviual missing modules
+        if not os.path.exists(".python_dependencies") or len(os.listdir()) < min_files:
+            e = "Python dependencies are missing. Click update to download full addon."
+        writeException(True, e)
+        return
     except Exception as e:
-        e = str(e)
-        if e.startswith("No module named"):
-            if not os.path.exists(".python_dependencies") or len(os.listdir()) < 10: # bump this up if more files get added to .python_dependencies in source
-                e = "Python dependencies are missing. Click update to download full addon."
         writeException(True, e)
         return
 

--- a/generator_process.py
+++ b/generator_process.py
@@ -164,7 +164,7 @@ def main():
         writeException(True, e)
         return
     except Exception as e:
-        writeException(True, e)
+        writeException(True, repr(e))
         return
 
     models_config  = absolute_path('stable_diffusion/configs/models.yaml')

--- a/generator_process.py
+++ b/generator_process.py
@@ -156,7 +156,7 @@ def main():
         from io import StringIO
     except ModuleNotFoundError as e:
         min_files = 10 # bump this up if more files get added to .python_dependencies in source
-                       # don't set too high so it can still pass info on indiviual missing modules
+                       # don't set too high so it can still pass info on individual missing modules
         if not os.path.exists(".python_dependencies") or len(os.listdir()) < min_files:
             e = "Python dependencies are missing. Click update to download full addon."
         writeException(True, e)

--- a/generator_process.py
+++ b/generator_process.py
@@ -7,6 +7,8 @@ import site
 import numpy as np
 from enum import IntEnum as Lawsuit
 
+MISSING_DEPENDENCIES_ERROR = "Python dependencies are missing. Click Download Latest Release to fix."
+
 # IPC message types from subprocess
 class Action(Lawsuit): # can't help myself
     UNKNOWN = -1
@@ -158,7 +160,7 @@ def main():
         min_files = 10 # bump this up if more files get added to .python_dependencies in source
                        # don't set too high so it can still pass info on individual missing modules
         if not os.path.exists(".python_dependencies") or len(os.listdir()) < min_files:
-            e = "Python dependencies are missing. Click update to download full addon."
+            e = MISSING_DEPENDENCIES_ERROR
         else:
             e = repr(e)
         writeException(True, e)

--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -7,7 +7,7 @@ from ..preferences import StableDiffusionPreferences
 from ..pil_to_image import *
 from ..prompt_engineering import *
 from ..absolute_path import WEIGHTS_PATH
-from ..generator_process import GeneratorProcess
+from ..generator_process import MISSING_DEPENDENCIES_ERROR, GeneratorProcess
 from ..property_groups.dream_prompt import DreamPrompt
 
 import tempfile
@@ -69,9 +69,9 @@ class DreamTexture(bpy.types.Operator):
             if fatal:
                 kill_generator()
             self.report({'ERROR'},err)
-            if err == "Python dependencies are missing. Click update to download full addon.":
-                from .open_latest_version import force_show_update
-                force_show_update()
+            if err == MISSING_DEPENDENCIES_ERROR:
+                from .open_latest_version import do_force_show_download
+                do_force_show_download()
 
 
         def step_progress_update(self, context):

--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -69,6 +69,9 @@ class DreamTexture(bpy.types.Operator):
             if fatal:
                 kill_generator()
             self.report({'ERROR'},err)
+            if err == "Python dependencies are missing. Click update to download full addon.":
+                from .open_latest_version import force_show_update
+                force_show_update()
 
 
         def step_progress_update(self, context):

--- a/operators/open_latest_version.py
+++ b/operators/open_latest_version.py
@@ -19,6 +19,9 @@ def check_for_updates():
 
 def new_version_available():
     return not latest_version == VERSION
+def force_show_update():
+    global VERSION
+    VERSION = (0,0,0)
 
 class OpenLatestVersion(bpy.types.Operator):
     bl_idname = "stable_diffusion.open_latest_version"

--- a/operators/open_latest_version.py
+++ b/operators/open_latest_version.py
@@ -18,10 +18,12 @@ def check_for_updates():
         pass
 
 def new_version_available():
-    return not latest_version == VERSION
+    return FORCE_SHOW_UPDATE or not latest_version == VERSION
+
+FORCE_SHOW_UPDATE = False
 def force_show_update():
-    global VERSION
-    VERSION = (0,0,0)
+    global FORCE_SHOW_UPDATE
+    FORCE_SHOW_UPDATE = True
 
 class OpenLatestVersion(bpy.types.Operator):
     bl_idname = "stable_diffusion.open_latest_version"

--- a/operators/open_latest_version.py
+++ b/operators/open_latest_version.py
@@ -18,12 +18,14 @@ def check_for_updates():
         pass
 
 def new_version_available():
-    return FORCE_SHOW_UPDATE or not latest_version == VERSION
+    return not latest_version == VERSION
 
-FORCE_SHOW_UPDATE = False
-def force_show_update():
-    global FORCE_SHOW_UPDATE
-    FORCE_SHOW_UPDATE = True
+force_show_download = False
+def do_force_show_download():
+    global force_show_download
+    force_show_download = True
+def is_force_show_download():
+    return force_show_download
 
 class OpenLatestVersion(bpy.types.Operator):
     bl_idname = "stable_diffusion.open_latest_version"

--- a/ui/panel.py
+++ b/ui/panel.py
@@ -4,7 +4,7 @@ from ..pil_to_image import *
 from ..prompt_engineering import *
 from ..operators.dream_texture import DreamTexture, ReleaseGenerator
 from ..operators.view_history import SCENE_UL_HistoryList, RecallHistoryEntry
-from ..operators.open_latest_version import OpenLatestVersion, new_version_available
+from ..operators.open_latest_version import OpenLatestVersion, is_force_show_download, new_version_available
 from ..help_section import help_section
 from ..preferences import StableDiffusionPreferences
 import sys
@@ -15,7 +15,9 @@ def draw_panel(self, context):
     layout = self.layout
     scene = context.scene
 
-    if new_version_available():
+    if is_force_show_download():
+        layout.operator(OpenLatestVersion.bl_idname, icon="IMPORT", text="Download Latest Release")
+    elif new_version_available():
         layout.operator(OpenLatestVersion.bl_idname, icon="IMPORT")
 
     prompt_box = layout.box()


### PR DESCRIPTION
Adds some error handling while loading dependencies within the subprocess and directs users who appear to have downloaded source to instead download from releases.
![blender_ogSY8cKMSl](https://user-images.githubusercontent.com/47096043/192170280-a552ad13-d0bd-46a2-b05f-9cc092b261fc.gif)
