### PR TITLE
Fixed context bug "AttributeError: 'SpaceDopeSheetEditor' object has …

### DIFF
--- a/ui/panel.py
+++ b/ui/panel.py
@@ -49,7 +49,8 @@ def draw_panel(self, context):
                     inpainting_heading.label(text="Inpaint Open Image")
                     break
 
-    if not scene.dream_textures_prompt.use_inpainting or area.spaces.active.image is None:
+    if not scene.dream_textures_prompt.use_inpainting or \
+        (hasattr(area.spaces.active,"image") and area.spaces.active.image is None):
         init_img_box = layout.box()
         init_img_heading = init_img_box.row()
         init_img_heading.prop(scene.dream_textures_prompt, "use_init_img")


### PR DESCRIPTION
…no attribute 'image'"

When the context is something other than the Image Editor, the panel throws an error about missing the 'image' attribute