### PR TITLE
Fix some install issues

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -43,19 +43,13 @@ requirements_path_items = (
     ('stable_diffusion/requirements-lin-AMD.txt', 'Linux (AMD)', 'Linux with AMD GPU'),
 )
 
-def childFromPath(parent, path):
-    for child in path:
-        if hasattr(parent, child):
-            parent = getattr(parent, child)
-        else:
-            return None
-    return parent
-
 def register():
-    if childFromPath(bpy.ops, DreamTexture.bl_idname.split(".")):
-        raise RuntimeError("Another instance of Dream Textures was still running during installation.\nPlease uninstall all instances of Dream Textures, then restart blender and try again.")
-        # could use addon_utils to disable the previous one but it likely installed to the same folder and may cause other issues
-        # best to have the previous completely removed before installing the next
+    dt_op = bpy.ops
+    for name in DreamTexture.bl_idname.split("."):
+        dt_op = getattr(dt_op, name)
+    if hasattr(bpy.types, dt_op.idname()): # objects under bpy.ops are created on the fly, have to check that it actually exists a little differently
+        raise RuntimeError("Another instance of Dream Textures is already running.")
+    
 
     bpy.types.Scene.dream_textures_requirements_path = EnumProperty(name="Platform", items=requirements_path_items, description="Specifies which set of dependencies to install", default='stable_diffusion/requirements-mac-MPS-CPU.txt' if sys.platform == 'darwin' else 'requirements-win-torch-1-11-0.txt')
     

--- a/__init__.py
+++ b/__init__.py
@@ -33,7 +33,7 @@ from .prompt_engineering import *
 from .operators.open_latest_version import check_for_updates
 from .classes import CLASSES, PREFERENCE_CLASSES
 from .tools import TOOLS
-from .operators.dream_texture import kill_generator
+from .operators.dream_texture import DreamTexture, kill_generator
 from .property_groups.dream_prompt import DreamPrompt
 
 requirements_path_items = (
@@ -43,7 +43,20 @@ requirements_path_items = (
     ('stable_diffusion/requirements-lin-AMD.txt', 'Linux (AMD)', 'Linux with AMD GPU'),
 )
 
+def childFromPath(parent, path):
+    for child in path:
+        if hasattr(parent, child):
+            parent = getattr(parent, child)
+        else:
+            return None
+    return parent
+
 def register():
+    if childFromPath(bpy.ops, DreamTexture.bl_idname.split(".")):
+        raise RuntimeError("Another instance of Dream Textures was still running during installation.\nPlease uninstall all instances of Dream Textures, then restart blender and try again.")
+        # could use addon_utils to disable the previous one but it likely installed to the same folder and may cause other issues
+        # best to have the previous completely removed before installing the next
+
     bpy.types.Scene.dream_textures_requirements_path = EnumProperty(name="Platform", items=requirements_path_items, description="Specifies which set of dependencies to install", default='stable_diffusion/requirements-mac-MPS-CPU.txt' if sys.platform == 'darwin' else 'requirements-win-torch-1-11-0.txt')
     
     register_section_props()

--- a/preferences.py
+++ b/preferences.py
@@ -86,11 +86,12 @@ class StableDiffusionPreferences(bpy.types.AddonPreferences):
     def draw(self, context):
         layout = self.layout
 
-        if not os.path.exists(absolute_path("stable_diffusion") or os.listdir(absolute_path("stable_diffusion")) < 5):
+        if not os.path.exists(absolute_path("stable_diffusion")) or len(os.listdir(absolute_path("stable_diffusion"))) < 5:
             missing_sd_box = layout.box()
             missing_sd_box.label(text="Stable diffusion is missing.", icon="ERROR")
             missing_sd_box.label(text="You've likely downloaded source instead of release by accident.")
             missing_sd_box.operator(OpenLatestVersion.bl_idname, text="Download Latest Release")
+            return
 
         weights_installed = os.path.exists(WEIGHTS_PATH)
 

--- a/preferences.py
+++ b/preferences.py
@@ -5,9 +5,11 @@ import sys
 import webbrowser
 from shutil import which
 
+
 from .help_section import help_section
-from .absolute_path import WEIGHTS_PATH
+from .absolute_path import WEIGHTS_PATH, absolute_path
 from .operators.install_dependencies import InstallDependencies
+from .operators.open_latest_version import OpenLatestVersion
 from .property_groups.dream_prompt import DreamPrompt
 
 class OpenHuggingFace(bpy.types.Operator):
@@ -83,6 +85,12 @@ class StableDiffusionPreferences(bpy.types.AddonPreferences):
 
     def draw(self, context):
         layout = self.layout
+
+        if not os.path.exists(absolute_path("stable_diffusion") or os.listdir(absolute_path("stable_diffusion")) < 5):
+            missing_sd_box = layout.box()
+            missing_sd_box.label(text="Stable diffusion is missing.", icon="ERROR")
+            missing_sd_box.label(text="You've likely downloaded source instead of release by accident.")
+            missing_sd_box.operator(OpenLatestVersion.bl_idname, text="Download Latest Release")
 
         weights_installed = os.path.exists(WEIGHTS_PATH)
 


### PR DESCRIPTION
Prevents a second installation of Dream Textures to be registered when one already is. Before it would cause some classes of the first installation to be unregistered, fail to fully register, and prevent the first installation from being able to be fully unregistered without a restart.

Also adds a warning when it appears to be installed from source zip in the preferences panel, previous "fix" #134 was insufficient as I forgot to account for the stable_diffusion directory not being included in source.
![image](https://user-images.githubusercontent.com/47096043/192931668-5c9a092a-cfd1-4c2b-b46c-5f688d1bc827.png)
