### PR TITLE
Subprocess IPC improvements

### DIFF
--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -1,4 +1,5 @@
 from importlib.resources import path
+import sys
 import bpy
 import os
 import math
@@ -64,12 +65,14 @@ class DreamTexture(bpy.types.Operator):
         def info(msg=""):
             scene.dream_textures_info = msg
         
-        def handle_exception(fatal, err):
+        def handle_exception(fatal, msg, trace):
             info() # clear variable
             if fatal:
                 kill_generator()
-            self.report({'ERROR'},err)
-            if err == MISSING_DEPENDENCIES_ERROR:
+            self.report({'ERROR'},msg)
+            if trace:
+                print(trace, file=sys.stderr)
+            if msg == MISSING_DEPENDENCIES_ERROR:
                 from .open_latest_version import do_force_show_download
                 do_force_show_download()
 


### PR DESCRIPTION
Redesigned backend to frontend IPC messages to be more easily modified and less prone to cause complicated issues like exceptions in the middle of writing an action to stdout. Added docstrings so other maintainers can better understand what a few parts do. Exception messages can now include a simplified user seen message and a stderr printed stacktrace, and has simplified integration when send_exception() is called within an except block. Message sending is also simplified by the send_action() function automatically packaging kwargs into json instead of individually writing things to stdout.

Fixes regression #192. The error check that is causing that regression has been swapped for a similar one that doesn't have expectations based on user input width and height.