### PR TITLE
Fix sampler argument

### DIFF
--- a/operators/view_history.py
+++ b/operators/view_history.py
@@ -14,7 +14,7 @@ class SCENE_UL_HistoryList(bpy.types.UIList):
                 layout.label(text=item.get_prompt_subject(), translate=False, icon_value=icon)
                 layout.label(text=f"{item.width}x{item.height}", translate=False)
                 layout.label(text=f"{item.steps} steps", translate=False)
-                layout.label(text=next(x for x in sampler_options if x[0] == item.sampler)[1], translate=False)
+                layout.label(text=next(x for x in sampler_options if x[0] == item.sampler_name)[1], translate=False)
         elif self.layout_type == 'GRID':
             layout.alignment = 'CENTER'
             layout.label(text="", icon_value=icon)

--- a/property_groups/dream_prompt.py
+++ b/property_groups/dream_prompt.py
@@ -42,7 +42,7 @@ attributes = {
     "iterations": IntProperty(name="Iterations", default=1, min=1, description="How many images to generate"),
     "steps": IntProperty(name="Steps", default=25, min=1),
     "cfg_scale": FloatProperty(name="CFG Scale", default=7.5, min=1, description="How strongly the prompt influences the image"),
-    "sampler": EnumProperty(name="Sampler", items=sampler_options, default=3),
+    "sampler_name": EnumProperty(name="Sampler", items=sampler_options, default=3),
     "show_steps": BoolProperty(name="Show Steps", description="Displays intermediate steps in the Image Viewer. Disabling can speed up generation", default=True),
 
     # Init Image

--- a/ui/panel.py
+++ b/ui/panel.py
@@ -74,7 +74,7 @@ def draw_panel(self, context):
         # advanced_box.prop(self, "iterations") # Disabled until supported by the addon.
         advanced_box.prop(scene.dream_textures_prompt, "steps")
         advanced_box.prop(scene.dream_textures_prompt, "cfg_scale")
-        advanced_box.prop(scene.dream_textures_prompt, "sampler")
+        advanced_box.prop(scene.dream_textures_prompt, "sampler_name")
         advanced_box.prop(scene.dream_textures_prompt, "show_steps")
     
     row = layout.row()


### PR DESCRIPTION
The sampler argument needed to be called `sampler_name`, this is why sampler choices were not being respected.