### PR TITLE
add backend image resizing

### DIFF
--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -92,7 +92,8 @@ headless_prompt = None
 headless_step_callback = None
 headless_image_callback = None
 headless_init_img = None
-def dream_texture(prompt, step_callback, image_callback, init_img=None):
+headless_args = None
+def dream_texture(prompt, step_callback, image_callback, init_img=None, **kwargs):
     global headless_prompt
     headless_prompt = prompt
     global headless_step_callback
@@ -101,6 +102,8 @@ def dream_texture(prompt, step_callback, image_callback, init_img=None):
     headless_image_callback = image_callback
     global headless_init_img
     headless_init_img = init_img
+    global headless_args
+    headless_args = kwargs
     bpy.ops.shade.dream_texture_headless()
 
 class HeadlessDreamTexture(bpy.types.Operator):
@@ -204,6 +207,7 @@ class HeadlessDreamTexture(bpy.types.Operator):
             init_img_path = save_temp_image(init_img)
 
         args = headless_prompt.generate_args()
+        args.update(headless_args)
         args['init_img'] = init_img_path
 
         def step_callback(step, width=None, height=None, shared_memory_name=None):

--- a/render_pass.py
+++ b/render_pass.py
@@ -75,7 +75,7 @@ def register_render_pass():
                             self.update_stats("Dream Textures", "Starting...")
                             event = threading.Event()
                             def do_dream_texture_pass():
-                                dream_texture(scene.dream_textures_render_properties_prompt, step_callback, functools.partial(image_callback, event), combined_pass_image)
+                                dream_texture(scene.dream_textures_render_properties_prompt, step_callback, functools.partial(image_callback, event), combined_pass_image, output_resize=(size_x, size_y))
                             bpy.app.timers.register(do_dream_texture_pass)
                             event.wait()
                             def cleanup():


### PR DESCRIPTION
Allows the backend to resize images before sending them to fix `TypeError: expected sequence size ...` when using the DT render pass and the output properties resolution doesn't match the images produced.