### PR TITLE
Clear Modules from a Previous Install

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -26,6 +26,14 @@ bl_info = {
 import bpy
 from bpy.props import IntProperty, PointerProperty, EnumProperty, BoolProperty
 import sys
+import os
+
+module_name = os.path.basename(os.path.dirname(__file__))
+def clear_modules():
+    for name in list(sys.modules.keys()):
+        if name.startswith(module_name) and name != module_name:
+            del sys.modules[name]
+clear_modules() # keep before all addon imports
 
 from .render_pass import register_render_pass, unregister_render_pass
 from .prompt_engineering import *


### PR DESCRIPTION
Blender (at least on Windows) will only reload `__init__.py` when the user enables the addon and detects that the file has changed, leaving all other modules from the addon still loaded and leads to `__init__.py` attempting to use out-of-date modules after installing a new version.

This change will allow  `__init__.py` to clear those modules so they too get reloaded.

Installing a new version will still require that the previous version is disabled, removed from Blender, or when left enabled it is disabled and enabled again after installed.
![blender_j6RmG2ZdAE](https://user-images.githubusercontent.com/47096043/194380398-67fef1ff-1859-452d-975c-62b86f56575a.gif)
Version is misleading. bl_info gets updated when the new version is installed. It was still running 0.0.6 at the start of the gif