### PR TITLE
More Subprocess Refactoring and Cancel Generate Operator

### DIFF
--- a/classes.py
+++ b/classes.py
@@ -1,6 +1,6 @@
 from .operators.install_dependencies import InstallDependencies
 from .operators.open_latest_version import OpenLatestVersion
-from .operators.dream_texture import DreamTexture, ReleaseGenerator, HeadlessDreamTexture
+from .operators.dream_texture import DreamTexture, ReleaseGenerator, HeadlessDreamTexture, CancelGenerator
 from .operators.view_history import SCENE_UL_HistoryList, RecallHistoryEntry, ClearHistory, RemoveHistorySelection, ExportHistorySelection, ImportPromptFile
 from .operators.inpaint_area_brush import InpaintAreaStroke
 from .operators.upscale import Upscale
@@ -14,6 +14,7 @@ CLASSES = (
     
     DreamTexture,
     ReleaseGenerator,
+    CancelGenerator,
     OpenLatestVersion,
     SCENE_UL_HistoryList,
     RecallHistoryEntry,

--- a/generator_process.py
+++ b/generator_process.py
@@ -341,7 +341,7 @@ class Backend():
             # Reset the step count
             step = 0
 
-            if generator is None or generator.precision != choose_precision(generator.device) if args['precision'] == 'auto' else args['precision']:
+            if generator is None or generator.precision != (choose_precision(generator.device) if args['precision'] == 'auto' else args['precision']):
                 self.send_info("Loading Model")
                 generator = Generate(
                     conf=models_config,

--- a/generator_process.py
+++ b/generator_process.py
@@ -475,9 +475,9 @@ class Backend():
 
         while True:
             if len(self.queue) == 0:
-                self.queue_appended.wait()
                 self.queue_appended.clear()
-            (intent, args) = self.queue.pop()
+                self.queue_appended.wait()
+            (intent, args) = self.queue.pop(0)
             if intent in intents:
                 self.intent = intent
                 self.stopped_was_sent = False

--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -129,10 +129,10 @@ class HeadlessDreamTexture(bpy.types.Operator):
         try:
             next(generator_advance)
         except StopIteration:
-            remove_timer(context)
+            modal_stopped(context)
             return {'FINISHED'}
         except Exception as e:
-            remove_timer(context)
+            modal_stopped(context)
             raise e
         return {'RUNNING_MODAL'}
 
@@ -242,7 +242,7 @@ def modal_stopped(context):
         context.window_manager.event_timer_remove(timer)
         timer = None
         if not hasattr(context,'scene'):
-            context = bpy.context
+            context = bpy.context # modal context is sometimes missing scene?
         context.scene.dream_textures_progress = 0
         context.scene.dream_textures_info = ""
     global last_data_block

--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -25,8 +25,7 @@ class DreamTexture(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        global timer
-        return timer is None
+        return GeneratorProcess.can_use()
     
     def execute(self, context):
         history_entry = context.preferences.addons[StableDiffusionPreferences.bl_idname].preferences.history.add()
@@ -113,8 +112,7 @@ class HeadlessDreamTexture(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        global timer
-        return timer is None
+        return GeneratorProcess.can_use()
 
     def invoke(self, context, event):
         weights_installed = os.path.exists(WEIGHTS_PATH)

--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -8,7 +8,7 @@ from ..preferences import StableDiffusionPreferences
 from ..pil_to_image import *
 from ..prompt_engineering import *
 from ..absolute_path import WEIGHTS_PATH
-from ..generator_process import MISSING_DEPENDENCIES_ERROR, GeneratorProcess
+from ..generator_process import MISSING_DEPENDENCIES_ERROR, GeneratorProcess, Intent
 from ..property_groups.dream_prompt import DreamPrompt
 
 import tempfile
@@ -65,7 +65,6 @@ class DreamTexture(bpy.types.Operator):
                 for area in screen.areas:
                     if area.type == 'IMAGE_EDITOR':
                         area.spaces.active.image = image
-                scene.dream_textures_progress = 0
                 scene.dream_textures_prompt.seed = str(seed) # update property in case seed was sourced randomly or from hash
                 history_entry.seed = str(seed)
                 history_entry.random_seed = False
@@ -233,24 +232,27 @@ class HeadlessDreamTexture(bpy.types.Operator):
             exception_callback=handle_exception
         )
         context.window_manager.modal_handler_add(self)
-        self.timer = context.window_manager.event_timer_add(1 / 15, window=context.window)
+        global timer
+        timer = context.window_manager.event_timer_add(1 / 15, window=context.window)
         return {'RUNNING_MODAL'}
 
-def remove_timer(context):
+def modal_stopped(context):
     global timer
     if timer:
         context.window_manager.event_timer_remove(timer)
         timer = None
-
-def kill_generator(context=bpy.context):
-    GeneratorProcess.kill_shared()
-    remove_timer(context)
-    bpy.context.scene.dream_textures_progress = 0
-    bpy.context.scene.dream_textures_info = ""
+        if not hasattr(context,'scene'):
+            context = bpy.context
+        context.scene.dream_textures_progress = 0
+        context.scene.dream_textures_info = ""
     global last_data_block
     if last_data_block is not None:
         bpy.data.images.remove(last_data_block)
         last_data_block = None
+
+def kill_generator(context=bpy.context):
+    GeneratorProcess.kill_shared()
+    modal_stopped(context)
 
 class ReleaseGenerator(bpy.types.Operator):
     bl_idname = "shade.dream_textures_release_generator"
@@ -260,4 +262,21 @@ class ReleaseGenerator(bpy.types.Operator):
 
     def execute(self, context):
         kill_generator(context)
+        return {'FINISHED'}
+
+class CancelGenerator(bpy.types.Operator):
+    bl_idname = "shade.dream_textures_stop_generator"
+    bl_label = "Cancel Generator"
+    bl_description = "Stops the generator without reloading everything next time"
+    bl_options = {'REGISTER'}
+
+    @classmethod
+    def poll(self, context):
+        global timer
+        return timer is not None
+
+    def execute(self, context):
+        gen = GeneratorProcess.shared(False)
+        if gen:
+            gen.send_stop(Intent.PROMPT_TO_IMAGE)
         return {'FINISHED'}

--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -241,10 +241,10 @@ def modal_stopped(context):
     if timer:
         context.window_manager.event_timer_remove(timer)
         timer = None
-        if not hasattr(context,'scene'):
-            context = bpy.context # modal context is sometimes missing scene?
-        context.scene.dream_textures_progress = 0
-        context.scene.dream_textures_info = ""
+    if not hasattr(context,'scene'):
+        context = bpy.context # modal context is sometimes missing scene?
+    context.scene.dream_textures_progress = 0
+    context.scene.dream_textures_info = ""
     global last_data_block
     if last_data_block is not None:
         bpy.data.images.remove(last_data_block)

--- a/operators/upscale.py
+++ b/operators/upscale.py
@@ -27,8 +27,7 @@ class Upscale(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        global timer
-        return timer is None
+        return GeneratorProcess.can_use()
 
     def modal(self, context, event):
         if event.type != 'TIMER':

--- a/ui/panels/dream_texture.py
+++ b/ui/panels/dream_texture.py
@@ -1,7 +1,7 @@
 from bpy.types import Panel
 from ...pil_to_image import *
 from ...prompt_engineering import *
-from ...operators.dream_texture import DreamTexture, ReleaseGenerator
+from ...operators.dream_texture import DreamTexture, ReleaseGenerator, CancelGenerator
 from ...operators.open_latest_version import OpenLatestVersion, is_force_show_download, new_version_available
 from ...operators.view_history import ImportPromptFile
 from ..space_types import SPACE_TYPES
@@ -233,5 +233,7 @@ def actions_panel(sub_panel, space_type, get_prompt):
                 disabled_row = row.row()
                 disabled_row.prop(context.scene, 'dream_textures_progress', slider=True)
                 disabled_row.enabled = False
+                if CancelGenerator.poll(context):
+                    row.operator(CancelGenerator.bl_idname, icon="CANCEL", text="")
             row.operator(ReleaseGenerator.bl_idname, icon="X", text="")
     return ActionsPanel

--- a/ui/panels/dream_texture.py
+++ b/ui/panels/dream_texture.py
@@ -233,7 +233,7 @@ def actions_panel(sub_panel, space_type, get_prompt):
                 disabled_row = row.row()
                 disabled_row.prop(context.scene, 'dream_textures_progress', slider=True)
                 disabled_row.enabled = False
-                if CancelGenerator.poll(context):
-                    row.operator(CancelGenerator.bl_idname, icon="CANCEL", text="")
+            if CancelGenerator.poll(context):
+                row.operator(CancelGenerator.bl_idname, icon="CANCEL", text="")
             row.operator(ReleaseGenerator.bl_idname, icon="X", text="")
     return ActionsPanel


### PR DESCRIPTION
- Cancel Generate operator allows for stopping without killing the subprocess and reloading everything next time
- Added `send_intent()` method to `GeneratorProcess` that mirrors what `send_action()` does
- Subprocess state is now managed by the `Backend` class to clean up `main()`
- Subprocess now uses a background thread for reading stdin so new intents can be processed while one is already running
- Intents are split into their own generator functions that allow for lazy loading their dependencies and models, won't have to wait on stable diffusion models if you're only starting the subprocess for upscaling
- Includes a fix for #265