### PR TITLE
delete pointers before closing shared memory

### DIFF
--- a/render_pass.py
+++ b/render_pass.py
@@ -55,6 +55,11 @@ def register_render_pass():
                                     pixels = np.frombuffer(shared_memory.buf, dtype=np.float32)
                                     reshaped = pixels.reshape((width * height, 4))
                                     render_pass.rect.foreach_set(reshaped)
+
+                                    # delete pointers before closing shared memory
+                                    del pixels
+                                    del reshaped
+
                                     shared_memory.close()
                                     event.set()
                             


### PR DESCRIPTION
Delete pointers into the shared memory buffer before closing the shared memory. Without this I got some errors when trying to close the buffer (on linux at least).

fixes #298 