### PR TITLE
Upscale Seamless Fix

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -84,6 +84,7 @@ def register():
     bpy.types.Scene.dream_textures_render_properties_prompt = PointerProperty(type=DreamPrompt)
     bpy.types.Scene.dream_textures_upscale_outscale = bpy.props.EnumProperty(name="Target Size", items=upscale_options)
     bpy.types.Scene.dream_textures_upscale_full_precision = bpy.props.BoolProperty(name="Full Precision", default=True)
+    bpy.types.Scene.dream_textures_upscale_seamless = bpy.props.BoolProperty(name="Seamless", default=False)
 
     for cls in CLASSES:
         bpy.utils.register_class(cls)

--- a/generator_process.py
+++ b/generator_process.py
@@ -431,6 +431,10 @@ class Backend():
         from realesrgan.archs.srvgg_arch import SRVGGNetCompact
         while True:
             image = cv2.imread(args['input'], cv2.IMREAD_UNCHANGED)
+            padding = 32
+            if args['seamless']:
+                image = np.pad(image, ((padding, padding), (padding, padding), (0, 0)), 'wrap')
+
             real_esrgan_model = SRVGGNetCompact(num_in_ch=3, num_out_ch=3, num_feat=64, num_conv=32, upscale=4, act_type='prelu')
             netscale = 4
             self.send_info("Loading Upsampler")
@@ -445,6 +449,9 @@ class Backend():
             )
             self.send_info("Enhancing Input")
             output, _ = upsampler.enhance(image, outscale=args['outscale'])
+            if args['seamless']:
+                padding *= args['outscale']
+                output = output[padding:-padding, padding:-padding]
             self.send_info("Converting Result")
             output = cv2.cvtColor(output, cv2.COLOR_BGR2RGB)
             output = Image.fromarray(output)

--- a/operators/upscale.py
+++ b/operators/upscale.py
@@ -125,6 +125,7 @@ class Upscale(bpy.types.Operator):
             'name': input_image.name,
             'outscale': int(context.scene.dream_textures_upscale_outscale),
             'full_precision': context.scene.dream_textures_upscale_full_precision,
+            'seamless': context.scene.dream_textures_upscale_seamless
         }
         global generator_advance
         generator_advance = generator.upscale(args, image_callback, info_callback, exception_callback)

--- a/ui/panels/upscaling.py
+++ b/ui/panels/upscaling.py
@@ -72,6 +72,7 @@ def upscaling_panels():
                 layout.enabled = os.path.exists(REAL_ESRGAN_WEIGHTS_PATH)
                 layout.prop(context.scene, "dream_textures_upscale_outscale")
                 layout.prop(context.scene, "dream_textures_upscale_full_precision")
+                layout.prop(context.scene, "dream_textures_upscale_seamless")
                 if not context.scene.dream_textures_upscale_full_precision:
                     box = layout.box()
                     box.label(text="Note: Some GPUs do not support mixed precision math", icon="ERROR")


### PR DESCRIPTION
This adds an extra checkbox to upscaling that'll prevent artifacts around the edges of a seamless texture. 
![blender_K34ckQV1kX](https://user-images.githubusercontent.com/47096043/196012845-e3852e4a-1803-4d51-bebb-2db98e03dc09.gif)