### PR TITLE
Advanced Presets

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -44,6 +44,7 @@ from .operators.dream_texture import DreamTexture, kill_generator
 from .property_groups.dream_prompt import DreamPrompt
 from .operators.upscale import upscale_options
 from .preferences import StableDiffusionPreferences
+from .ui.presets import register_default_presets
 
 requirements_path_items = (
     # Use the old version of requirements-win.txt to fix installation issues with Blender + PyTorch 1.12.1
@@ -93,6 +94,8 @@ def register():
 
     # Monkey patch cycles render passes
     register_render_pass()
+
+    register_default_presets()
 
 def unregister():
     for cls in PREFERENCE_CLASSES:

--- a/absolute_path.py
+++ b/absolute_path.py
@@ -8,5 +8,5 @@ def absolute_path(component):
     """
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), component)
 
-WEIGHTS_PATH = absolute_path("stable_diffusion/models/ldm/stable-diffusion-v1/model.ckpt")
+WEIGHTS_PATH = absolute_path("weights/stable-diffusion-v1.4/model.ckpt")
 REAL_ESRGAN_WEIGHTS_PATH = absolute_path("weights/realesrgan/realesr-general-x4v3.pth")

--- a/builtin_presets/Debug.py
+++ b/builtin_presets/Debug.py
@@ -1,0 +1,10 @@
+import bpy
+prompt = bpy.context.scene.dream_textures_prompt
+
+prompt.precision = 'auto'
+prompt.random_seed = True
+prompt.seed = '0'
+prompt.steps = 25
+prompt.cfg_scale = 7.5
+prompt.sampler_name = 'k_lms'
+prompt.show_steps = True

--- a/builtin_presets/Final.py
+++ b/builtin_presets/Final.py
@@ -1,0 +1,10 @@
+import bpy
+prompt = bpy.context.scene.dream_textures_prompt
+
+prompt.precision = 'auto'
+prompt.random_seed = True
+prompt.seed = '0'
+prompt.steps = 50
+prompt.cfg_scale = 7.5
+prompt.sampler_name = 'k_lms'
+prompt.show_steps = False

--- a/builtin_presets/Preview.py
+++ b/builtin_presets/Preview.py
@@ -1,0 +1,10 @@
+import bpy
+prompt = bpy.context.scene.dream_textures_prompt
+
+prompt.precision = 'auto'
+prompt.random_seed = True
+prompt.seed = '0'
+prompt.steps = 25
+prompt.cfg_scale = 7.5
+prompt.sampler_name = 'k_lms'
+prompt.show_steps = False

--- a/classes.py
+++ b/classes.py
@@ -8,6 +8,8 @@ from .property_groups.dream_prompt import DreamPrompt
 from .ui.panels import dream_texture, history, upscaling, render_properties
 from .preferences import OpenGitDownloads, OpenHuggingFace, OpenWeightsDirectory, OpenRustInstaller, ValidateInstallation, StableDiffusionPreferences
 
+from .ui.presets import DREAM_PT_AdvancedPresets, DREAM_MT_AdvancedPresets, AddAdvancedPreset
+
 CLASSES = (
     HeadlessDreamTexture,
     *render_properties.render_properties_panels(),
@@ -24,6 +26,10 @@ CLASSES = (
     ImportPromptFile,
     InpaintAreaStroke,
     Upscale,
+
+    DREAM_PT_AdvancedPresets,
+    DREAM_MT_AdvancedPresets,
+    AddAdvancedPreset,
     
     # The order these are registered in matters
     *dream_texture.dream_texture_panels(),

--- a/classes.py
+++ b/classes.py
@@ -8,7 +8,7 @@ from .property_groups.dream_prompt import DreamPrompt
 from .ui.panels import dream_texture, history, upscaling, render_properties
 from .preferences import OpenGitDownloads, OpenHuggingFace, OpenWeightsDirectory, OpenRustInstaller, ValidateInstallation, StableDiffusionPreferences
 
-from .ui.presets import DREAM_PT_AdvancedPresets, DREAM_MT_AdvancedPresets, AddAdvancedPreset
+from .ui.presets import DREAM_PT_AdvancedPresets, DREAM_MT_AdvancedPresets, AddAdvancedPreset, RestoreDefaultPresets
 
 CLASSES = (
     HeadlessDreamTexture,
@@ -48,4 +48,5 @@ PREFERENCE_CLASSES = (
                       OpenWeightsDirectory,
                       OpenRustInstaller,
                       ValidateInstallation,
+                      RestoreDefaultPresets,
                       StableDiffusionPreferences)

--- a/generator_process/intents/prompt_to_image.py
+++ b/generator_process/intents/prompt_to_image.py
@@ -35,15 +35,10 @@ def prompt_to_image(self):
     self.send_info("Importing Dependencies")
     from absolute_path import absolute_path
     from stable_diffusion.ldm.generate import Generate
-    from stable_diffusion.ldm.dream.devices import choose_precision
-    from omegaconf import OmegaConf
+    from stable_diffusion.ldm.invoke.devices import choose_precision
     from io import StringIO
-    models_config  = absolute_path('stable_diffusion/configs/models.yaml')
-    model   = 'stable-diffusion-1.4'
-
-    models  = OmegaConf.load(models_config)
-    config  = absolute_path('stable_diffusion/' + models[model].config)
-    weights = absolute_path('stable_diffusion/' + models[model].weights)
+    
+    models_config  = absolute_path('weights/config.yml')
     generator: Generate = None
 
     def image_writer(image, seed, upscaled=False, first_seed=None):
@@ -127,10 +122,6 @@ def prompt_to_image(self):
                 self.send_info("Loading Model")
                 generator = Generate(
                     conf=models_config,
-                    model=model,
-                    # These args are deprecated, but we need them to specify an absolute path to the weights.
-                    weights=weights,
-                    config=config,
                     precision=args['precision']
                 )
                 generator.free_gpu_mem = False # Not sure what this is for, and why it isn't a flag but read from Args()?

--- a/preferences.py
+++ b/preferences.py
@@ -9,6 +9,7 @@ from .absolute_path import WEIGHTS_PATH, absolute_path
 from .operators.install_dependencies import InstallDependencies
 from .operators.open_latest_version import OpenLatestVersion
 from .property_groups.dream_prompt import DreamPrompt
+from .ui.presets import RestoreDefaultPresets, default_presets_missing
 
 class OpenHuggingFace(bpy.types.Operator):
     bl_idname = "stable_diffusion.open_hugging_face"
@@ -127,6 +128,13 @@ class StableDiffusionPreferences(bpy.types.AddonPreferences):
             complete_box.label(text="1. Open an Image Editor or Shader Editor space")
             complete_box.label(text="2. Enable 'View' > 'Sidebar'")
             complete_box.label(text="3. Select the 'Dream' tab")
+        
+        if default_presets_missing():
+            presets_box = layout.box()
+            presets_box.label(text="Default Presets", icon="PRESET")
+            presets_box.label(text="It looks like you removed some of the default presets.")
+            presets_box.label(text="You can restore them here.")
+            presets_box.operator(RestoreDefaultPresets.bl_idname, icon="RECOVER_LAST")
 
         if context.preferences.view.show_developer_ui: # If 'Developer Extras' is enabled, show addon development tools
             developer_box = layout.box()

--- a/property_groups/dream_prompt.py
+++ b/property_groups/dream_prompt.py
@@ -51,7 +51,7 @@ attributes = {
     "steps": IntProperty(name="Steps", default=25, min=1),
     "cfg_scale": FloatProperty(name="CFG Scale", default=7.5, min=1, soft_min=1.01, description="How strongly the prompt influences the image"),
     "sampler_name": EnumProperty(name="Sampler", items=sampler_options, default=3),
-    "show_steps": BoolProperty(name="Show Steps", description="Displays intermediate steps in the Image Viewer. Disabling can speed up generation", default=True),
+    "show_steps": BoolProperty(name="Show Steps", description="Displays intermediate steps in the Image Viewer. Disabling can speed up generation", default=False),
 
     # Init Image
     "use_init_img": BoolProperty(name="Use Init Image", default=False),

--- a/ui/panels/dream_texture.py
+++ b/ui/panels/dream_texture.py
@@ -1,4 +1,5 @@
 from bpy.types import Panel
+from ..presets import DREAM_PT_AdvancedPresets
 from ...pil_to_image import *
 from ...prompt_engineering import *
 from ...operators.dream_texture import DreamTexture, ReleaseGenerator, CancelGenerator
@@ -193,6 +194,9 @@ def advanced_panel(sub_panel, space_type, get_prompt):
         bl_idname = f"DREAM_PT_dream_panel_advanced_{space_type}"
         bl_label = "Advanced"
         bl_options = {'DEFAULT_CLOSED'}
+
+        def draw_header_preset(self, context):
+            DREAM_PT_AdvancedPresets.draw_panel_header(self.layout)
 
         def draw(self, context):
             super().draw(context)

--- a/ui/presets.py
+++ b/ui/presets.py
@@ -1,0 +1,54 @@
+import bpy
+from bpy.types import Panel, Operator, Menu
+from bl_operators.presets import AddPresetBase
+from bl_ui.utils import PresetPanel
+import os
+import shutil
+from ..absolute_path import absolute_path
+
+class DreamTexturesPresetPanel(PresetPanel, Panel):
+    preset_operator = "script.execute_preset"
+
+    # @staticmethod
+    # def post_cb(context):
+    #     # Modify an arbitrary built-in scene property to force a depsgraph
+    #     # update, because add-on properties don't. (see T62325)
+    #     render = context.scene.render
+    #     render.filter_size = render.filter_size
+
+class DREAM_PT_AdvancedPresets(DreamTexturesPresetPanel):
+    bl_label = "Advanced Presets"
+    preset_subdir = "dream_textures/advanced"
+    preset_add_operator = "dream_textures.advanced_preset_add"
+
+class DREAM_MT_AdvancedPresets(Menu):
+    bl_label = 'Advanced Presets'
+    preset_subdir = 'dream_textures/advanced'
+    preset_operator = 'script.execute_preset'
+    draw = Menu.draw_preset
+
+class AddAdvancedPreset(AddPresetBase, Operator):
+    bl_idname = 'dream_textures.advanced_preset_add'
+    bl_label = 'Add Advanced Preset'
+    preset_menu = 'DREAM_MT_AdvancedPresets'
+    
+    preset_subdir = 'dream_textures/advanced'
+    
+    preset_defines = ['prompt = bpy.context.scene.dream_textures_prompt']
+    preset_values = [
+        "prompt.precision",
+        "prompt.random_seed",
+        "prompt.seed",
+        "prompt.steps",
+        "prompt.cfg_scale",
+        "prompt.sampler_name",
+        "prompt.show_steps",
+    ]
+
+def register_default_presets():
+    presets_path = os.path.join(bpy.utils.user_resource('SCRIPTS'), 'presets/dream_textures/advanced')
+    default_presets_path = absolute_path('builtin_presets')
+    if not os.path.isdir(presets_path):
+        os.makedirs(presets_path)
+        for default_preset in os.listdir(default_presets_path):
+            shutil.copy(os.path.join(default_presets_path, default_preset), presets_path)

--- a/ui/presets.py
+++ b/ui/presets.py
@@ -45,10 +45,30 @@ class AddAdvancedPreset(AddPresetBase, Operator):
         "prompt.show_steps",
     ]
 
-def register_default_presets():
-    presets_path = os.path.join(bpy.utils.user_resource('SCRIPTS'), 'presets/dream_textures/advanced')
-    default_presets_path = absolute_path('builtin_presets')
-    if not os.path.isdir(presets_path):
-        os.makedirs(presets_path)
-        for default_preset in os.listdir(default_presets_path):
-            shutil.copy(os.path.join(default_presets_path, default_preset), presets_path)
+class RestoreDefaultPresets(Operator):
+    bl_idname = "dream_textures.restore_default_presets"
+    bl_label = "Restore Default Presets"
+    bl_description = ("Restores all default presets provided by the addon.")
+    bl_options = {"REGISTER", "INTERNAL"}
+
+    def execute(self, context):
+        register_default_presets(force=True)
+        return {"FINISHED"}
+
+PRESETS_PATH = os.path.join(bpy.utils.user_resource('SCRIPTS'), 'presets/dream_textures/advanced')
+DEFAULT_PRESETS_PATH = absolute_path('builtin_presets')
+def register_default_presets(force=False):
+    presets_path_exists = os.path.isdir(PRESETS_PATH)
+    if not presets_path_exists or force:
+        if not presets_path_exists:
+            os.makedirs(PRESETS_PATH)
+        for default_preset in os.listdir(DEFAULT_PRESETS_PATH):
+            if not os.path.exists(os.path.join(PRESETS_PATH, default_preset)):
+                shutil.copy(os.path.join(DEFAULT_PRESETS_PATH, default_preset), PRESETS_PATH)
+
+def default_presets_missing():
+    if not os.path.isdir(PRESETS_PATH):
+        return True
+    for default_preset in os.listdir(DEFAULT_PRESETS_PATH):
+        if not os.path.exists(os.path.join(PRESETS_PATH, default_preset)):
+            return True

--- a/weights/config.yml
+++ b/weights/config.yml
@@ -1,0 +1,6 @@
+stable-diffusion-1.4:
+  config: stable_diffusion/configs/stable-diffusion/v1-inference.yaml
+  weights: weights/stable-diffusion-v1.4/model.ckpt
+  description: Stable Diffusion inference model version 1.4
+  width: 512
+  height: 512

--- a/weights/stable-diffusion-v1.4/.gitignore
+++ b/weights/stable-diffusion-v1.4/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
This adds the ability to create and load presets for the 'Advanced' panel with the built-in Blender UI:
<img width="423" alt="Screen Shot 2022-10-16 at 9 06 22 PM" src="https://user-images.githubusercontent.com/13581484/196068901-e932ea75-7084-4ef0-8dce-9256e21c34f0.png">

Three defaults are included:
* Preview - lower steps for prototyping
  * Steps 25
  * Show Steps: Off
* Final - higher steps for final generations
  * Steps 50
  * Show Steps: Off
* Debug - shows each step
  * Steps 25
  * Show Steps: On

> **Note** Model weights were moved to `weights/stable-diffusion-v1.4`, so they are no longer in `stable_diffusion/models/ldm/stable-diffusion-v1`