### PR TITLE
Check Weights Installed Fix

### DIFF
--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -16,6 +16,12 @@ generator_advance = None
 last_data_block = None
 timer = None
 
+def weights_are_installed(report = None):
+    weights_installed = os.path.exists(WEIGHTS_PATH)
+    if report and (not weights_installed):
+        report({'ERROR'}, "Please complete setup in the preferences window.")
+    return weights_installed
+
 class DreamTexture(bpy.types.Operator):
     bl_idname = "shade.dream_texture"
     bl_label = "Dream Texture"
@@ -25,7 +31,12 @@ class DreamTexture(bpy.types.Operator):
     @classmethod
     def poll(cls, context):
         return GeneratorProcess.can_use()
-    
+
+    def invoke(self, context, event):
+        if weights_are_installed(self.report):
+            return self.execute(context)
+        return {'CANCELLED'}
+
     def execute(self, context):
         history_entry = context.preferences.addons[StableDiffusionPreferences.bl_idname].preferences.history.add()
         for prop in context.scene.dream_textures_prompt.__annotations__.keys():
@@ -112,13 +123,6 @@ class HeadlessDreamTexture(bpy.types.Operator):
     @classmethod
     def poll(cls, context):
         return GeneratorProcess.can_use()
-
-    def invoke(self, context, event):
-        weights_installed = os.path.exists(WEIGHTS_PATH)
-        if not weights_installed:
-            self.report({'ERROR'}, "Please complete setup in the preferences window.")
-            return {'CANCELLED'}
-        return self.execute(context)
 
     def modal(self, context, event):
         if event.type != 'TIMER':

--- a/render_pass.py
+++ b/render_pass.py
@@ -10,7 +10,7 @@ from multiprocessing.shared_memory import SharedMemory
 
 from .generator_process import GeneratorProcess
 
-from .operators.dream_texture import dream_texture
+from .operators.dream_texture import dream_texture, weights_are_installed
 
 update_render_passes_original = cycles.CyclesRender.update_render_passes
 render_original = cycles.CyclesRender.render
@@ -40,6 +40,8 @@ def register_render_pass():
                 size_y = int(scene.render.resolution_y * scale)
                 if size_x % 64 != 0 or size_y % 64 != 0:
                     self.report({"ERROR"}, f"Image dimensions must be multiples of 64 (e.x. 512x512, 512x768, ...) closest is {round(size_x/64)*64}x{round(size_y/64)*64}")
+                    return result
+                if not weights_are_installed(self.report):
                     return result
                 render_result = self.begin_result(0, 0, size_x, size_y)
                 for original_layer in original_result.layers:


### PR DESCRIPTION
Due to the way the `HeadlessDreamTexture` operator is run it will not call its `invoke()` method. That could be fixed by calling `bpy.ops.shade.dream_texture_headless()` with `'INVOKE_DEFAULT'` as its first argument, but that causes a whole stack trace to be reported instead of just its intended simple message for some reason. Same thing would happen if checking that the weights were installed within `execute()` method.

Instead it'll have to check for them in the original `DreamTexture` operator's `invoke()` method, and added an extra check within the render pass since that directly uses `HeadlessDreamTexture`.

Fixes #289 