### PR TITLE
Fix InpaintAreaBrush behavior

### DIFF
--- a/classes.py
+++ b/classes.py
@@ -2,7 +2,7 @@ from .operators.install_dependencies import InstallDependencies
 from .operators.open_latest_version import OpenLatestVersion
 from .operators.dream_texture import DreamTexture, ReleaseGenerator, HeadlessDreamTexture, CancelGenerator
 from .operators.view_history import SCENE_UL_HistoryList, RecallHistoryEntry, ClearHistory, RemoveHistorySelection, ExportHistorySelection, ImportPromptFile
-from .operators.inpaint_area_brush import InpaintAreaStroke
+from .operators.inpaint_area_brush import InpaintAreaBrushActivated
 from .operators.upscale import Upscale
 from .property_groups.dream_prompt import DreamPrompt
 from .ui.panels import dream_texture, history, upscaling, render_properties
@@ -24,7 +24,7 @@ CLASSES = (
     RemoveHistorySelection,
     ExportHistorySelection,
     ImportPromptFile,
-    InpaintAreaStroke,
+    InpaintAreaBrushActivated,
     Upscale,
 
     DREAM_PT_AdvancedPresets,

--- a/operators/inpaint_area_brush.py
+++ b/operators/inpaint_area_brush.py
@@ -1,62 +1,22 @@
 import bpy
-import math
 
-is_painting = False
-last_stroke = None
-time = 0
-paint_event = None
+reset_blend_mode = 'MIX'
+class InpaintAreaBrushActivated(bpy.types.GizmoGroup):
+    bl_idname = "dream_textures.inpaint_area_brush_activated"
+    bl_label = "Inpaint Area Brush Activated"
+    bl_space_type = 'IMAGE_EDITOR'
+    bl_context_mode = 'PAINT'
+    bl_region_type = 'WINDOW'
 
-class InpaintAreaStroke(bpy.types.Operator):
-    bl_idname = 'dream_textures.inpaint_area_stroke'
-    bl_label = "Mark Area for Inpainting"
-    bl_description = "Marks the area for inpainting by setting the alpha to 0 while keeping RGB values"
-    bl_options = {'REGISTER'}
+    def setup(self, context):
+        global reset_blend_mode
+        reset_blend_mode = bpy.data.brushes["TexDraw"].blend
+        def set_blend():
+            bpy.data.brushes["TexDraw"].blend = "ERASE_ALPHA"
+        bpy.app.timers.register(set_blend)
 
-    firing_mode: bpy.props.IntProperty()
-    alpha_mode: bpy.props.BoolProperty(default=False)
-
-    def invoke(self, context, event):
-        global is_painting
-        global last_stroke
-        global time
-        if self.firing_mode == 0: # PRESS
-            is_painting = True
-        elif self.firing_mode == 2: # RELEASE
-            is_painting = False
-            last_stroke = None
-            time = 0
-        elif self.firing_mode == 1 and is_painting: # MOVE
-            original_tool = context.workspace.tools.from_space_image_mode('PAINT').idname
-        
-            bpy.ops.paint.brush_select(image_tool='DRAW', toggle=False)
-            brush = bpy.data.brushes["TexDraw"]
-            brush.use_pressure_strength = False
-            brush.blend = 'ADD_ALPHA' if self.alpha_mode else 'ERASE_ALPHA'
-            context.tool_settings.image_paint.brush = brush
-            stroke = {
-                "name": "stroke",
-                "mouse": (event.mouse_x, event.mouse_y - context.scene.tool_settings.unified_paint_settings.size),
-                "mouse_event": (0,0),
-                "pen_flip" : True,
-                "is_start": True if last_stroke is None else False,
-                "location": (0, 0, 0),
-                "size": context.scene.tool_settings.unified_paint_settings.size,
-                "pressure": 1,
-                "x_tilt": 0,
-                "y_tilt": 0,
-                "time": float(time)
-            }
-            if last_stroke is not None:
-                with context.temp_override():
-                    bpy.ops.paint.image_paint(stroke=[last_stroke, stroke], mode='NORMAL')
-            last_stroke = stroke
-            time += 1
-            bpy.ops.wm.tool_set_by_id(name=original_tool)
-        
-        return {"FINISHED"}
-
-    def execute(self, context):
-        return {"FINISHED"}
+    def __del__(self):
+        bpy.data.brushes["TexDraw"].blend = reset_blend_mode
 
 class InpaintAreaBrush(bpy.types.WorkSpaceTool):
     bl_space_type = 'IMAGE_EDITOR'
@@ -66,17 +26,7 @@ class InpaintAreaBrush(bpy.types.WorkSpaceTool):
     bl_label = "Mark Inpaint Area"
     bl_description = "Mark an area for inpainting"
     bl_icon = "brush.gpencil_draw.tint"
-    bl_widget = None
-    bl_keymap = (
-        # Subtract
-        (InpaintAreaStroke.bl_idname, {"type": 'LEFTMOUSE', "value": 'PRESS'}, {"properties": [("firing_mode", 0)]}),
-        (InpaintAreaStroke.bl_idname, {"type": 'MOUSEMOVE', "value": 'ANY'}, {"properties": [("firing_mode", 1)]}),
-        (InpaintAreaStroke.bl_idname, {"type": 'LEFTMOUSE', "value": 'RELEASE'}, {"properties": [("firing_mode", 2)]}),
-        # Add - FIXME: Support adding back alpha. So far I have been unable to find a way to customize the custom tool behavior as a brush.
-        (InpaintAreaStroke.bl_idname, {"type": 'LEFTMOUSE', "value": 'PRESS', "ctrl": True}, {"properties": [("firing_mode", 0), ("alpha_mode", True)]}),
-        (InpaintAreaStroke.bl_idname, {"type": 'MOUSEMOVE', "value": 'ANY', "ctrl": True}, {"properties": [("firing_mode", 1), ("alpha_mode", True)]}),
-        (InpaintAreaStroke.bl_idname, {"type": 'LEFTMOUSE', "value": 'RELEASE', "ctrl": True}, {"properties": [("firing_mode", 2), ("alpha_mode", True)]}),
-    )
+    bl_widget = InpaintAreaBrushActivated.bl_idname
 
     def draw_settings(self, layout, tool):
         # context.scene.tool_settings.unified_paint_settings

--- a/operators/inpaint_area_brush.py
+++ b/operators/inpaint_area_brush.py
@@ -29,5 +29,4 @@ class InpaintAreaBrush(bpy.types.WorkSpaceTool):
     bl_widget = InpaintAreaBrushActivated.bl_idname
 
     def draw_settings(self, layout, tool):
-        # context.scene.tool_settings.unified_paint_settings
         layout.prop(bpy.context.scene.tool_settings.unified_paint_settings, 'size')

--- a/operators/inpaint_area_brush.py
+++ b/operators/inpaint_area_brush.py
@@ -21,6 +21,7 @@ class InpaintAreaBrushActivated(bpy.types.GizmoGroup):
             bpy.data.brushes["TexDraw"].blend = "ERASE_ALPHA"
             bpy.data.brushes["TexDraw"].curve_preset = "CONSTANT"
             bpy.data.brushes["TexDraw"].strength = 1.0
+            bpy.ops.paint.brush_select(image_tool='DRAW', toggle=False)
         bpy.app.timers.register(set_blend)
 
     def __del__(self):

--- a/operators/inpaint_area_brush.py
+++ b/operators/inpaint_area_brush.py
@@ -1,6 +1,7 @@
 import bpy
 
 reset_blend_mode = 'MIX'
+reset_curve_preset = 'CUSTOM'
 class InpaintAreaBrushActivated(bpy.types.GizmoGroup):
     bl_idname = "dream_textures.inpaint_area_brush_activated"
     bl_label = "Inpaint Area Brush Activated"
@@ -10,13 +11,17 @@ class InpaintAreaBrushActivated(bpy.types.GizmoGroup):
 
     def setup(self, context):
         global reset_blend_mode
+        global reset_curve_preset
         reset_blend_mode = bpy.data.brushes["TexDraw"].blend
+        reset_curve_preset = bpy.data.brushes["TexDraw"].curve_preset
         def set_blend():
             bpy.data.brushes["TexDraw"].blend = "ERASE_ALPHA"
+            bpy.data.brushes["TexDraw"].curve_preset = "CONSTANT"
         bpy.app.timers.register(set_blend)
 
     def __del__(self):
         bpy.data.brushes["TexDraw"].blend = reset_blend_mode
+        bpy.data.brushes["TexDraw"].curve_preset = reset_curve_preset
 
 class InpaintAreaBrush(bpy.types.WorkSpaceTool):
     bl_space_type = 'IMAGE_EDITOR'

--- a/operators/inpaint_area_brush.py
+++ b/operators/inpaint_area_brush.py
@@ -2,6 +2,7 @@ import bpy
 
 reset_blend_mode = 'MIX'
 reset_curve_preset = 'CUSTOM'
+reset_strength = 1.0
 class InpaintAreaBrushActivated(bpy.types.GizmoGroup):
     bl_idname = "dream_textures.inpaint_area_brush_activated"
     bl_label = "Inpaint Area Brush Activated"
@@ -12,16 +13,20 @@ class InpaintAreaBrushActivated(bpy.types.GizmoGroup):
     def setup(self, context):
         global reset_blend_mode
         global reset_curve_preset
+        global reset_strength
         reset_blend_mode = bpy.data.brushes["TexDraw"].blend
         reset_curve_preset = bpy.data.brushes["TexDraw"].curve_preset
+        reset_strength = bpy.data.brushes["TexDraw"].strength
         def set_blend():
             bpy.data.brushes["TexDraw"].blend = "ERASE_ALPHA"
             bpy.data.brushes["TexDraw"].curve_preset = "CONSTANT"
+            bpy.data.brushes["TexDraw"].strength = 1.0
         bpy.app.timers.register(set_blend)
 
     def __del__(self):
         bpy.data.brushes["TexDraw"].blend = reset_blend_mode
         bpy.data.brushes["TexDraw"].curve_preset = reset_curve_preset
+        bpy.data.brushes["TexDraw"].strength = reset_strength
 
 class InpaintAreaBrush(bpy.types.WorkSpaceTool):
     bl_space_type = 'IMAGE_EDITOR'


### PR DESCRIPTION
This replaces the manual stroke operator with a `GizmoGroup` that updates the "Draw" brush's blend mode when the "Mark Inpaint Area" brush is selected/de-selected.

Another hack, but this one seems to actually work well.