### PR TITLE
Init Image Redesign and Outpainting

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -77,7 +77,7 @@ def register():
         return ""
     bpy.types.Scene.dream_textures_history_selection = IntProperty(default=1)
     bpy.types.Scene.dream_textures_history_selection_preview = bpy.props.StringProperty(name="", default="", get=get_selection_preview, set=lambda _, __: None)
-    bpy.types.Scene.dream_textures_progress = bpy.props.IntProperty(name="Progress", default=0, min=0, max=0)
+    bpy.types.Scene.dream_textures_progress = bpy.props.IntProperty(name="", default=0, min=0, max=0)
     bpy.types.Scene.dream_textures_info = bpy.props.StringProperty(name="Info")
 
     bpy.types.Scene.dream_textures_render_properties_enabled = BoolProperty(default=False)

--- a/absolute_path.py
+++ b/absolute_path.py
@@ -10,3 +10,4 @@ def absolute_path(component):
 
 WEIGHTS_PATH = absolute_path("weights/stable-diffusion-v1.4/model.ckpt")
 REAL_ESRGAN_WEIGHTS_PATH = absolute_path("weights/realesrgan/realesr-general-x4v3.pth")
+CLIPSEG_WEIGHTS_PATH = absolute_path("weights/clipseg/rd64-uni.pth")

--- a/classes.py
+++ b/classes.py
@@ -37,7 +37,10 @@ CLASSES = (
     *history.history_panels(),
 
     upscaling.OpenRealESRGANDownload,
-    upscaling.OpenRealESRGANWeightsDirectory
+    upscaling.OpenRealESRGANWeightsDirectory,
+
+    dream_texture.OpenClipSegDownload,
+    dream_texture.OpenClipSegWeightsDirectory,
 )
 
 PREFERENCE_CLASSES = (

--- a/generator_process/__init__.py
+++ b/generator_process/__init__.py
@@ -274,7 +274,7 @@ def main():
             from ctypes import WinDLL
             WinDLL(os.path.join(os.path.dirname(sys.argv[1]),"python3.dll")) # fix for ImportError: DLL load failed while importing cv2: The specified module could not be found.
 
-        from absolute_path import absolute_path
+        from absolute_path import absolute_path, CLIPSEG_WEIGHTS_PATH
         # Support Apple Silicon GPUs as much as possible.
         os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
 
@@ -286,6 +286,7 @@ def main():
         sys.path.append(absolute_path("stable_diffusion/src/clip"))
         sys.path.append(absolute_path("stable_diffusion/src/k-diffusion"))
         sys.path.append(absolute_path("stable_diffusion/src/taming-transformers"))
+        sys.path.append(absolute_path("stable_diffusion/src/clipseg"))
         site.addsitedir(absolute_path(".python_dependencies"))
         sys.path.extend(paths)
 
@@ -296,6 +297,9 @@ def main():
             import scipy # This will hang when loading libbanded5x.Q3V52YHHGVBP5BKVHJ5RHQVFWHHSLVWO.gfortran-win_amd64.dll
                          # if imported while background reading thread is waiting on next intent.
                          # Hurray for more strange .dll bugs
+
+        from ldm.invoke import txt2mask
+        txt2mask.CLIPSEG_WEIGHTS = CLIPSEG_WEIGHTS_PATH
 
         back.thread.start()
         back.main_loop()

--- a/generator_process/__init__.py
+++ b/generator_process/__init__.py
@@ -293,10 +293,14 @@ def main():
         import pkg_resources
         pkg_resources._initialize_master_working_set()
 
+        # Import specific modules that cause subprocess to hang if first imported after the background thread is started
         if sys.platform == 'win32':
-            import scipy # This will hang when loading libbanded5x.Q3V52YHHGVBP5BKVHJ5RHQVFWHHSLVWO.gfortran-win_amd64.dll
-                         # if imported while background reading thread is waiting on next intent.
-                         # Hurray for more strange .dll bugs
+            # I'm not sure if scipy will be an issue since we're not using a version that has
+            # libbanded5x.Q3V52YHHGVBP5BKVHJ5RHQVFWHHSLVWO.gfortran-win_amd64.dll anymore.
+            # Importing skimage is indirectly loading scipy anyway. Keeping note for future reference.
+
+            # Couldn't track down exactly where it was hanging but it's good enough.
+            from skimage import transform
 
         from ldm.invoke import txt2mask
         txt2mask.CLIPSEG_WEIGHTS = CLIPSEG_WEIGHTS_PATH

--- a/generator_process/intents/prompt_to_image.py
+++ b/generator_process/intents/prompt_to_image.py
@@ -156,7 +156,7 @@ def prompt_to_image(self):
                     generator_args['text_mask'] = (generator_args['text_mask'], generator_args['text_mask_confidence'])
                 else:
                     generator_args['text_mask'] = None
-                if args['init_img_action'] == 'outpaint':
+                if args['use_init_img'] and args['init_img_action'] == 'outpaint':
                     args['fit'] = False
                     # Extend the image in the specified directions
                     from PIL import Image, ImageFilter

--- a/generator_process/intents/prompt_to_image.py
+++ b/generator_process/intents/prompt_to_image.py
@@ -119,7 +119,7 @@ def prompt_to_image(self):
 
         start_preloading("CLIP Segmentation")
         from absolute_path import CLIPSEG_WEIGHTS_PATH
-        from models.clipseg import CLIPDensePredT
+        from clipseg_models.clipseg import CLIPDensePredT
         CLIPDensePredT(version='ViT-B/16', reduce_dim=64)
 
         tqdm.update = old_update

--- a/generator_process/intents/prompt_to_image.py
+++ b/generator_process/intents/prompt_to_image.py
@@ -167,7 +167,9 @@ def prompt_to_image(self):
                     blurred_fill.putalpha(0)
                     extended_img.paste(blurred_fill, (0, 0))
                     extended_img.paste(init_img, (args['outpaint_left'], args['outpaint_top']))
-                    extended_img.save(args['init_img'], 'png')
+                    extended_img.save(generator_args['init_img'], 'png')
+                    generator_args['width'] = extended_size[0]
+                    generator_args['height'] = extended_size[1]
                 generator.prompt2image(
                     # a function or method that will be called each step
                     step_callback=view_step,

--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -167,7 +167,7 @@ class HeadlessDreamTexture(bpy.types.Operator):
             return None
 
         bpy.types.Scene.dream_textures_progress = bpy.props.IntProperty(
-            name="Progress",
+            name="",
             default=0,
             min=0,
             max=(int(headless_prompt.strength * headless_prompt.steps) if init_img is not None else headless_prompt.steps) + 1,
@@ -206,10 +206,13 @@ class HeadlessDreamTexture(bpy.types.Operator):
         init_img_path = None
         if init_img is not None:
             init_img_path = save_temp_image(init_img)
+            print(init_img_path)
 
         args = headless_prompt.generate_args()
         args.update(headless_args)
         args['init_img'] = init_img_path
+        if headless_prompt.use_init_img_color:
+            args['init_color'] = init_img_path
 
         def step_callback(step, width=None, height=None, shared_memory_name=None):
             global headless_step_callback

--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -7,7 +7,7 @@ from multiprocessing.shared_memory import SharedMemory
 from ..preferences import StableDiffusionPreferences
 from ..pil_to_image import *
 from ..prompt_engineering import *
-from ..absolute_path import WEIGHTS_PATH
+from ..absolute_path import WEIGHTS_PATH, CLIPSEG_WEIGHTS_PATH
 from ..generator_process import MISSING_DEPENDENCIES_ERROR, GeneratorProcess, Intent
 
 import tempfile
@@ -143,7 +143,7 @@ class HeadlessDreamTexture(bpy.types.Operator):
         scene = context.scene
 
         global headless_init_img
-        init_img = headless_init_img or (scene.init_img if headless_prompt.use_init_img else None)
+        init_img = headless_init_img or (scene.init_img if headless_prompt.use_init_img and headless_prompt.init_img_src == 'file' else None)
 
         def info(msg=""):
             scene.dream_textures_info = msg
@@ -198,7 +198,7 @@ class HeadlessDreamTexture(bpy.types.Operator):
 
             return path
 
-        if headless_prompt.use_inpainting:
+        if headless_prompt.use_init_img and headless_prompt.init_img_src == 'open_editor':
             for area in screen.areas:
                 if area.type == 'IMAGE_EDITOR':
                     if area.spaces.active.image is not None:

--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -224,7 +224,7 @@ class HeadlessDreamTexture(bpy.types.Operator):
             global headless_image_callback
             info() # clear variable
             nonlocal received_noncolorized
-            if headless_prompt.use_init_img_color and not received_noncolorized:
+            if headless_prompt.use_init_img and headless_prompt.use_init_img_color and not received_noncolorized:
                 received_noncolorized = True
                 return
             received_noncolorized = False

--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -219,9 +219,15 @@ class HeadlessDreamTexture(bpy.types.Operator):
             scene.dream_textures_progress = step + 1
             headless_step_callback(step, width, height, shared_memory_name)
 
+        received_noncolorized = False
         def image_callback(shared_memory_name, seed, width, height, upscaled=False):
             global headless_image_callback
             info() # clear variable
+            nonlocal received_noncolorized
+            if headless_prompt.use_init_img_color and not received_noncolorized:
+                received_noncolorized = True
+                return
+            received_noncolorized = False
             headless_image_callback(shared_memory_name, seed, width, height, upscaled)
 
         global generator_advance

--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -206,7 +206,6 @@ class HeadlessDreamTexture(bpy.types.Operator):
         init_img_path = None
         if init_img is not None:
             init_img_path = save_temp_image(init_img)
-            print(init_img_path)
 
         args = headless_prompt.generate_args()
         args.update(headless_args)

--- a/property_groups/dream_prompt.py
+++ b/property_groups/dream_prompt.py
@@ -75,6 +75,7 @@ attributes = {
     "init_img_action": EnumProperty(name="Action", items=init_image_actions, default="modify"),
     "strength": FloatProperty(name="Noise Strength", description="The ratio of noise:image. A higher value gives more 'creative' results", default=0.75, min=0, max=1, soft_min=0.01, soft_max=0.99),
     "fit": BoolProperty(name="Fit to width/height", default=True),
+    "use_init_img_color": BoolProperty(name="Color Correct", default=True),
     
     # Inpaint
     "inpaint_mask_src": EnumProperty(name="Mask Source", items=inpaint_mask_sources, default="alpha"),
@@ -87,6 +88,7 @@ attributes = {
     "outpaint_right": IntProperty(name="Right", default=64, step=64, min=0),
     "outpaint_bottom": IntProperty(name="Bottom", default=64, step=64, min=0),
     "outpaint_left": IntProperty(name="Left", default=64, step=64, min=0),
+    "outpaint_blend": IntProperty(name="Blend", description="Gaussian blur amount to apply to the extended area", default=16, min=0),
 }
 
 def map_structure_token_items(value):

--- a/render_pass.py
+++ b/render_pass.py
@@ -14,14 +14,13 @@ from .operators.dream_texture import dream_texture, weights_are_installed
 
 update_render_passes_original = cycles.CyclesRender.update_render_passes
 render_original = cycles.CyclesRender.render
-del_original = cycles.CyclesRender.__del__
+# del_original = cycles.CyclesRender.__del__
 
 def register_render_pass():
     def update_render_passes_decorator(original):
         def update_render_passes(self, scene=None, renderlayer=None):
             result = original(self, scene, renderlayer)
             self.register_pass(scene, renderlayer, "Dream Textures", 4, "RGBA", 'COLOR')
-            self.register_pass(scene, renderlayer, "Dream Textures Seed", 1, "X", 'VALUE')
             return result
         return update_render_passes
     cycles.CyclesRender.update_render_passes = update_render_passes_decorator(cycles.CyclesRender.update_render_passes)
@@ -34,7 +33,6 @@ def register_render_pass():
             try:
                 original_result = self.get_result()
                 self.add_pass("Dream Textures", 4, "RGBA")
-                self.add_pass("Dream Textures Seed", 1, "X")
                 scale = scene.render.resolution_percentage / 100.0
                 size_x = int(scene.render.resolution_x * scale)
                 size_y = int(scene.render.resolution_y * scale)
@@ -87,15 +85,10 @@ def register_render_pass():
                         if render_pass.name == "Dream Textures":
                             self.update_stats("Dream Textures", "Starting")
                             def image_callback(event, set_pixels, shared_memory_name, seed, width, height, upscaled=False):
-                                self.update_stats("Dream Textures", "Pushing to render pass")
                                 # Only use the non-upscaled texture, as upscaling is currently unsupported by the addon.
                                 if not upscaled:
                                     shared_memory = SharedMemory(shared_memory_name)
                                     set_pixels(np.frombuffer(shared_memory.buf, dtype=np.float32).copy().reshape((size_x * size_y, 4)))
-
-                                    seed_pass = next(filter(lambda x: x.name == "Dream Textures Seed", layer.passes))
-                                    seed_pass_data = np.repeat(np.float32(float(seed)), len(seed_pass.rect))
-                                    seed_pass.rect.foreach_set(seed_pass_data)
 
                                     shared_memory.close()
 
@@ -132,7 +125,7 @@ def register_render_pass():
                                 nonlocal pixels
                                 pixels = npbuf
                             def do_dream_texture_pass():
-                                dream_texture(scene.dream_textures_render_properties_prompt, step_callback, functools.partial(image_callback, event, set_pixels), combined_pass_image, width=size_x, height=size_y, show_steps=False)
+                                dream_texture(scene.dream_textures_render_properties_prompt, step_callback, functools.partial(image_callback, event, set_pixels), combined_pass_image, width=size_x, height=size_y, show_steps=False, use_init_img_color=False)
                             bpy.app.timers.register(do_dream_texture_pass)
                             event.wait()
 
@@ -157,7 +150,7 @@ def register_render_pass():
                                 bpy.data.images.remove(combined_pass_image)
                             bpy.app.timers.register(cleanup)
                             self.update_stats("Dream Textures", "Finished")
-                        elif render_pass.name != "Dream Textures Seed":
+                        else:
                             pixels = np.empty((len(original_render_pass.rect), len(original_render_pass.rect[0])), dtype=np.float32)
                             original_render_pass.rect.foreach_get(pixels)
                             render_pass.rect[:] = pixels

--- a/requirements-lin-win-colab-CUDA.txt
+++ b/requirements-lin-win-colab-CUDA.txt
@@ -25,6 +25,7 @@ transformers==4.19.2
 git+https://github.com/openai/CLIP.git@main#egg=clip
 git+https://github.com/lstein/k-diffusion.git@master#egg=k-diffusion
 git+https://github.com/lstein/GFPGAN@fix-dark-cast-images#egg=gfpgan
+git+https://github.com/invoke-ai/clipseg.git#egg=clipseg
 # No CUDA in PyPi builds
 --extra-index-url https://download.pytorch.org/whl/cu113 --trusted-host https://download.pytorch.org
 torch==1.11.0

--- a/requirements-lin-win-colab-CUDA.txt
+++ b/requirements-lin-win-colab-CUDA.txt
@@ -25,7 +25,7 @@ transformers==4.19.2
 git+https://github.com/openai/CLIP.git@main#egg=clip
 git+https://github.com/lstein/k-diffusion.git@master#egg=k-diffusion
 git+https://github.com/lstein/GFPGAN@fix-dark-cast-images#egg=gfpgan
-git+https://github.com/invoke-ai/clipseg.git#egg=clipseg
+-e git+https://github.com/invoke-ai/clipseg.git@models-rename#egg=clipseg
 # No CUDA in PyPi builds
 --extra-index-url https://download.pytorch.org/whl/cu113 --trusted-host https://download.pytorch.org
 torch==1.11.0

--- a/requirements-mac-MPS-CPU.txt
+++ b/requirements-mac-MPS-CPU.txt
@@ -1,4 +1,4 @@
--r requirements.txt
+-r stable_diffusion/requirements.txt
 
 --pre
 --extra-index-url https://download.pytorch.org/whl/nightly/cpu --trusted-host https://download.pytorch.org

--- a/ui/panels/dream_texture.py
+++ b/ui/panels/dream_texture.py
@@ -172,7 +172,7 @@ def init_image_panels(sub_panel, space_type, get_prompt):
     class InitImagePanel(sub_panel):
         """Create a subpanel for init image options"""
         bl_idname = f"DREAM_PT_dream_panel_init_image_{space_type}"
-        bl_label = "Modify Image"
+        bl_label = "Source Image"
         bl_options = {'DEFAULT_CLOSED'}
 
         def draw_header(self, context):

--- a/ui/panels/dream_texture.py
+++ b/ui/panels/dream_texture.py
@@ -1,4 +1,11 @@
 from bpy.types import Panel
+from bpy_extras.io_utils import ImportHelper
+
+import webbrowser
+import os
+import shutil
+
+from ...absolute_path import CLIPSEG_WEIGHTS_PATH
 from ..presets import DREAM_PT_AdvancedPresets
 from ...pil_to_image import *
 from ...prompt_engineering import *
@@ -7,7 +14,6 @@ from ...operators.open_latest_version import OpenLatestVersion, is_force_show_do
 from ...operators.view_history import ImportPromptFile
 from ..space_types import SPACE_TYPES
 from ...property_groups.dream_prompt import DreamPrompt
-import types
 
 def dream_texture_panels():
     for space_type in SPACE_TYPES:
@@ -47,7 +53,7 @@ def dream_texture_panels():
             return context.scene.dream_textures_prompt
         yield from create_panel(space_type, 'UI', DreamTexturePanel.bl_idname, prompt_panel, get_prompt)
         yield create_panel(space_type, 'UI', DreamTexturePanel.bl_idname, size_panel, get_prompt)
-        yield from create_panel(space_type, 'UI', DreamTexturePanel.bl_idname, inpaint_init_image_panels, get_prompt)
+        yield from create_panel(space_type, 'UI', DreamTexturePanel.bl_idname, init_image_panels, get_prompt)
         yield create_panel(space_type, 'UI', DreamTexturePanel.bl_idname, advanced_panel, get_prompt)
         yield create_panel(space_type, 'UI', DreamTexturePanel.bl_idname, actions_panel, get_prompt)
 
@@ -131,48 +137,43 @@ def size_panel(sub_panel, space_type, get_prompt):
             layout.prop(get_prompt(context), "height")
     return SizePanel
 
-def inpaint_init_image_panels(sub_panel, space_type, get_prompt):
-    class InpaintPanel(sub_panel):
-        """Create a subpanel for inpainting options"""
-        bl_idname = f"DREAM_PT_dream_panel_inpaint_{space_type}"
-        bl_label = "Inpaint Open Image"
-        bl_options = {'DEFAULT_CLOSED'}
+class OpenClipSegDownload(bpy.types.Operator):
+    bl_idname = "dream_textures.open_clipseg_download"
+    bl_label = "Download Weights"
+    bl_description = ("Opens to where the weights can be downloaded.")
+    bl_options = {"REGISTER", "INTERNAL"}
 
-        @classmethod
-        def poll(self, context):
-            if not get_prompt(context).use_init_img:
-                for area in context.screen.areas:
-                    if area.type == 'IMAGE_EDITOR':
-                        if area.spaces.active.image is not None:
-                            return True
-            return False
+    def execute(self, context):
+        webbrowser.open("https://owncloud.gwdg.de/index.php/s/ioHbRzFx6th32hn")
+        return {"FINISHED"}
 
-        def draw_header(self, context):
-            self.layout.prop(get_prompt(context), "use_inpainting", text="")
+class OpenClipSegWeightsDirectory(bpy.types.Operator, ImportHelper):
+    bl_idname = "dream_textures.open_clipseg_weights_directory"
+    bl_label = "Import Model Weights"
+    bl_description = ("Opens the directory that should contain the 'realesr-general-x4v3.pth' file")
 
-        def draw(self, context):
-            super().draw(context)
-            layout = self.layout
-            layout.use_property_split = True
-            layout.enabled = get_prompt(context).use_inpainting
+    filename_ext = ".pth"
+    filter_glob: bpy.props.StringProperty(
+        default="*.pth",
+        options={'HIDDEN'},
+        maxlen=255,
+    )
 
-            layout.label(text="1. Open an Image Editor space")
-            layout.label(text="2. Select the 'Paint' editing context")
-            layout.label(text="3. Choose the 'Mark Inpaint Area' brush")
-            layout.label(text="4. Draw over the area to inpaint")
-    yield InpaintPanel
+    def execute(self, context):
+        _, extension = os.path.splitext(self.filepath)
+        if extension != '.pth':
+            self.report({"ERROR"}, "Select a valid '.pth' file.")
+            return {"FINISHED"}
+        shutil.copy(self.filepath, CLIPSEG_WEIGHTS_PATH)
+        
+        return {"FINISHED"}
 
+def init_image_panels(sub_panel, space_type, get_prompt):
     class InitImagePanel(sub_panel):
         """Create a subpanel for init image options"""
         bl_idname = f"DREAM_PT_dream_panel_init_image_{space_type}"
-        bl_label = "Init Image"
+        bl_label = "Modify Image"
         bl_options = {'DEFAULT_CLOSED'}
-
-        @classmethod
-        def poll(self, context):
-            if get_prompt(context).use_inpainting and InpaintPanel.poll(context):
-                return False
-            return True
 
         def draw_header(self, context):
             self.layout.prop(get_prompt(context), "use_init_img", text="")
@@ -180,12 +181,38 @@ def inpaint_init_image_panels(sub_panel, space_type, get_prompt):
         def draw(self, context):
             super().draw(context)
             layout = self.layout
+            prompt = get_prompt(context)
+            layout.enabled = prompt.use_init_img
+            
+            layout.prop(prompt, "init_img_src", expand=True)
+            if prompt.init_img_src == 'file':
+                layout.template_ID(context.scene, "init_img", open="image.open")
+            layout.prop(prompt, "init_img_action", expand=True)
+            
             layout.use_property_split = True
             
-            layout.enabled = get_prompt(context).use_init_img
-            layout.template_ID(context.scene, "init_img", open="image.open")
-            layout.prop(get_prompt(context), "strength")
-            layout.prop(get_prompt(context), "fit")
+            if prompt.init_img_action == 'inpaint':
+                layout.prop(prompt, "inpaint_mask_src")
+                if prompt.inpaint_mask_src == 'prompt':
+                    if not os.path.exists(CLIPSEG_WEIGHTS_PATH):
+                        layout.label(text="CLIP Segmentation model weights not installed.")
+                        layout.label(text="1. Download the file 'rd64-uni.pth'")
+                        layout.operator(OpenClipSegDownload.bl_idname, icon="URL")
+                        layout.label(text="2. Select the downloaded weights to install.")
+                        layout.operator(OpenClipSegWeightsDirectory.bl_idname, icon="IMPORT")
+                    else:
+                        layout.prop(prompt, "text_mask")
+                        layout.prop(prompt, "text_mask_confidence")
+                layout.prop(prompt, "strength")
+                layout.prop(prompt, "inpaint_replace")
+            elif prompt.init_img_action == 'outpaint':
+                layout.prop(prompt, "outpaint_top")
+                layout.prop(prompt, "outpaint_right")
+                layout.prop(prompt, "outpaint_bottom")
+                layout.prop(prompt, "outpaint_left")
+            elif prompt.init_img_action == 'modify':
+                layout.prop(prompt, "strength")
+                layout.prop(prompt, "fit")
     yield InitImagePanel
 
 def advanced_panel(sub_panel, space_type, get_prompt):

--- a/ui/panels/dream_texture.py
+++ b/ui/panels/dream_texture.py
@@ -203,16 +203,22 @@ def init_image_panels(sub_panel, space_type, get_prompt):
                     else:
                         layout.prop(prompt, "text_mask")
                         layout.prop(prompt, "text_mask_confidence")
-                layout.prop(prompt, "strength")
                 layout.prop(prompt, "inpaint_replace")
             elif prompt.init_img_action == 'outpaint':
-                layout.prop(prompt, "outpaint_top")
-                layout.prop(prompt, "outpaint_right")
-                layout.prop(prompt, "outpaint_bottom")
-                layout.prop(prompt, "outpaint_left")
+                column = layout.column(align=True)
+                column.prop(prompt, "outpaint_top")
+                column.prop(prompt, "outpaint_right")
+                column.prop(prompt, "outpaint_bottom")
+                column.prop(prompt, "outpaint_left")
+
+                layout.separator()
+                
+                layout.prop(prompt, "outpaint_blend")
+                layout.prop(prompt, "inpaint_replace")
             elif prompt.init_img_action == 'modify':
-                layout.prop(prompt, "strength")
                 layout.prop(prompt, "fit")
+            layout.prop(prompt, "strength")
+            layout.prop(prompt, "use_init_img_color")
     yield InitImagePanel
 
 def advanced_panel(sub_panel, space_type, get_prompt):
@@ -262,6 +268,7 @@ def actions_panel(sub_panel, space_type, get_prompt):
                     row.operator(DreamTexture.bl_idname, icon="PLAY", text="Generate")
             else:
                 disabled_row = row.row()
+                disabled_row.use_property_split = True
                 disabled_row.prop(context.scene, 'dream_textures_progress', slider=True)
                 disabled_row.enabled = False
             if CancelGenerator.poll(context):

--- a/weights/clipseg/.gitignore
+++ b/weights/clipseg/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
* The init image panel was redesigned to better support multiple types of image manipulation:

<img width="327" alt="Screen Shot 2022-10-19 at 1 26 18 PM" src="https://user-images.githubusercontent.com/13581484/196762378-1996c0c5-9caf-41f3-86cd-1f824b699947.png">

* 'Replace' option for inpainting allows the masked area to be replaced by noise
* 'Prompt' mask source uses CLIP segmentation to create an inpainting mask from a text prompt
* Outpainting support added, with a simple stretch/blur fill used to provide backing color information. The 'Replace' option could also be used to simply fill the new area with noise.

> **Note** A new git dependency was added for `clipseg` in the latest InvokeAI changes.