### PR TITLE
Add section linking to GH contributors

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -13,13 +13,11 @@
 
 bl_info = {
     "name": "Dream Textures",
-    "author": "Carson Katri, Greg Richardson, Kevin C. Burke",
+    "author": "Dream Textures contributors",
     "description": "Use Stable Diffusion to generate unique textures straight from the shader editor.",
-    "warning": "Requires installation of Stable Diffusion model weights",
     "blender": (3, 0, 0),
     "version": (0, 0, 7),
-    "location": "",
-    "warning": "",
+    "location": "Image Editor -> Sidebar -> Dream",
     "category": "Paint"
 }
 

--- a/classes.py
+++ b/classes.py
@@ -6,7 +6,7 @@ from .operators.inpaint_area_brush import InpaintAreaStroke
 from .operators.upscale import Upscale
 from .property_groups.dream_prompt import DreamPrompt
 from .ui.panels import dream_texture, history, upscaling, render_properties
-from .preferences import OpenGitDownloads, OpenHuggingFace, OpenWeightsDirectory, OpenRustInstaller, ValidateInstallation, StableDiffusionPreferences
+from .preferences import OpenHuggingFace, OpenWeightsDirectory, OpenContributors, StableDiffusionPreferences
 
 from .ui.presets import DREAM_PT_AdvancedPresets, DREAM_MT_AdvancedPresets, AddAdvancedPreset, RestoreDefaultPresets
 
@@ -42,11 +42,9 @@ CLASSES = (
 
 PREFERENCE_CLASSES = (
                       DreamPrompt,
-                      OpenGitDownloads,
                       InstallDependencies,
                       OpenHuggingFace,
                       OpenWeightsDirectory,
-                      OpenRustInstaller,
-                      ValidateInstallation,
+                      OpenContributors,
                       RestoreDefaultPresets,
                       StableDiffusionPreferences)

--- a/preferences.py
+++ b/preferences.py
@@ -12,7 +12,7 @@ from .property_groups.dream_prompt import DreamPrompt
 from .ui.presets import RestoreDefaultPresets, default_presets_missing
 
 class OpenHuggingFace(bpy.types.Operator):
-    bl_idname = "stable_diffusion.open_hugging_face"
+    bl_idname = "dream_textures.open_hugging_face"
     bl_label = "Download Weights from Hugging Face"
     bl_description = ("Opens huggingface.co to the download page for the model weights.")
     bl_options = {"REGISTER", "INTERNAL"}
@@ -21,18 +21,8 @@ class OpenHuggingFace(bpy.types.Operator):
         webbrowser.open("https://huggingface.co/CompVis/stable-diffusion-v-1-4-original")
         return {"FINISHED"}
 
-class OpenGitDownloads(bpy.types.Operator):
-    bl_idname = "stable_diffusion.open_git_downloads"
-    bl_label = "Go to git-scm.com"
-    bl_description = ("Opens git-scm.com to the download page for Git")
-    bl_options = {"REGISTER", "INTERNAL"}
-
-    def execute(self, context):
-        webbrowser.open("https://git-scm.com/downloads")
-        return {"FINISHED"}
-
 class OpenWeightsDirectory(bpy.types.Operator, ImportHelper):
-    bl_idname = "stable_diffusion.open_weights_directory"
+    bl_idname = "dream_textures.open_weights_directory"
     bl_label = "Import Model Weights"
     filename_ext = ".ckpt"
     filter_glob: bpy.props.StringProperty(
@@ -53,36 +43,12 @@ class OpenWeightsDirectory(bpy.types.Operator, ImportHelper):
         
         return {"FINISHED"}
 
-is_install_valid = None
-
-class OpenRustInstaller(bpy.types.Operator):
-    bl_idname = "stable_diffusion.open_rust_installer"
-    bl_label = "Go to rust-lang.org"
-    bl_description = ("Opens rust-lang.org to the install page")
-    bl_options = {"REGISTER", "INTERNAL"}
+class OpenContributors(bpy.types.Operator):
+    bl_idname = "dream_textures.open_contributors"
+    bl_label = "See All Contributors"
 
     def execute(self, context):
-        webbrowser.open("https://www.rust-lang.org/tools/install")
-        return {"FINISHED"}
-
-class ValidateInstallation(bpy.types.Operator):
-    bl_idname = "stable_diffusion.validate_installation"
-    bl_label = "Validate Installation"
-    bl_description = ("Tests importing the generator to locate a subset of errors with the installation")
-    bl_options = {"REGISTER", "INTERNAL"}
-
-    def execute(self, context):
-        global is_install_valid
-        try:
-            # Support Apple Silicon GPUs as much as possible.
-            os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
-            from .stable_diffusion.ldm.generate import Generate
-            
-            is_install_valid = True
-        except Exception as e:
-            self.report({"ERROR"}, str(e))
-            is_install_valid = False
-
+        webbrowser.open("https://github.com/carson-katri/dream-textures/graphs/contributors")
         return {"FINISHED"}
 
 class StableDiffusionPreferences(bpy.types.AddonPreferences):
@@ -135,11 +101,20 @@ class StableDiffusionPreferences(bpy.types.AddonPreferences):
             presets_box.label(text="It looks like you removed some of the default presets.")
             presets_box.label(text="You can restore them here.")
             presets_box.operator(RestoreDefaultPresets.bl_idname, icon="RECOVER_LAST")
+        
+        contributors_box = layout.box()
+        contributors_box.label(text="Contributors", icon="COMMUNITY")
+        contributors_box.label(text="Dream Textures is made possible by the contributors on GitHub.")
+        contributors_box.operator(OpenContributors.bl_idname, icon="URL")
 
         if context.preferences.view.show_developer_ui: # If 'Developer Extras' is enabled, show addon development tools
             developer_box = layout.box()
             developer_box.label(text="Development Tools", icon="CONSOLE")
             developer_box.label(text="This section is for addon development only. You are seeing this because you have 'Developer Extras' enabled.")
             developer_box.label(text="Do not use any operators in this section unless you are setting up a development environment.")
+            already_installed = len(os.listdir(absolute_path(".python_dependencies"))) > 0
+            if already_installed:
+                warn_box = developer_box.box()
+                warn_box.label(text="Dependencies already installed. Only install below if you developing the addon", icon="CHECKMARK")
             developer_box.prop(context.scene, 'dream_textures_requirements_path')
             developer_box.operator(InstallDependencies.bl_idname, icon="CONSOLE")


### PR DESCRIPTION
Updates the "author" info to simply say "Dream Textures contributors" and links to the contributors section of GitHub for more information. I also cleaned up some unused operators and added more clarification around "Install Dependencies" (as some users still try to use this).