### PR TITLE
clipseg fix

### DIFF
--- a/generator_process/__init__.py
+++ b/generator_process/__init__.py
@@ -293,10 +293,14 @@ def main():
         import pkg_resources
         pkg_resources._initialize_master_working_set()
 
+        # Import specific modules that cause subprocess to hang if first imported after the background thread is started
         if sys.platform == 'win32':
-            import scipy # This will hang when loading libbanded5x.Q3V52YHHGVBP5BKVHJ5RHQVFWHHSLVWO.gfortran-win_amd64.dll
-                         # if imported while background reading thread is waiting on next intent.
-                         # Hurray for more strange .dll bugs
+            # I'm not sure if scipy will be an issue since we're not using a version that has
+            # libbanded5x.Q3V52YHHGVBP5BKVHJ5RHQVFWHHSLVWO.gfortran-win_amd64.dll anymore.
+            # Importing skimage is indirectly loading scipy anyway. Keeping note for future reference.
+
+            # Couldn't track down exactly where it was hanging but it's good enough.
+            from skimage import transform
 
         from ldm.invoke import txt2mask
         txt2mask.CLIPSEG_WEIGHTS = CLIPSEG_WEIGHTS_PATH

--- a/generator_process/intents/prompt_to_image.py
+++ b/generator_process/intents/prompt_to_image.py
@@ -119,7 +119,7 @@ def prompt_to_image(self):
 
         start_preloading("CLIP Segmentation")
         from absolute_path import CLIPSEG_WEIGHTS_PATH
-        from models.clipseg import CLIPDensePredT
+        from clipseg_models.clipseg import CLIPDensePredT
         CLIPDensePredT(version='ViT-B/16', reduce_dim=64)
 
         tqdm.update = old_update

--- a/requirements-lin-win-colab-CUDA.txt
+++ b/requirements-lin-win-colab-CUDA.txt
@@ -25,7 +25,7 @@ transformers==4.19.2
 git+https://github.com/openai/CLIP.git@main#egg=clip
 git+https://github.com/lstein/k-diffusion.git@master#egg=k-diffusion
 git+https://github.com/lstein/GFPGAN@fix-dark-cast-images#egg=gfpgan
-git+https://github.com/invoke-ai/clipseg.git#egg=clipseg
+-e git+https://github.com/invoke-ai/clipseg.git@models-rename#egg=clipseg
 # No CUDA in PyPi builds
 --extra-index-url https://download.pytorch.org/whl/cu113 --trusted-host https://download.pytorch.org
 torch==1.11.0


### PR DESCRIPTION
Had an issue that's already been addressed upstream: [ModuleNotFoundError: No module named 'models.clipseg'](https://github.com/invoke-ai/InvokeAI/issues/1150), and ran into another issue with a different module causing the subprocess to hang when attempting to generate.