### PR TITLE
Render Pass Fix

### DIFF
--- a/generator_process/block_in_use.py
+++ b/generator_process/block_in_use.py
@@ -2,11 +2,16 @@ def block_in_use(func):
     def block(self, *args, **kwargs):
         if self.in_use:
             raise RuntimeError(f"Can't call {func.__qualname__} while process is in use")
-        try:
-            self.in_use = True
-            yield from func(self, *args, **kwargs)
-        finally:
-            self.in_use = False
+        self.in_use = True
+
+        # generator function is separate so in_use gets set immediately rather than waiting for first next() call
+        def sub():
+            try:
+                yield from func(self, *args, **kwargs)
+            finally:
+                self.in_use = False
+        return sub()
+
     # Pass the name through so we can use it in `setattr` on `GeneratorProcess`.
     block.__name__ = func.__name__
     return block

--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -238,12 +238,12 @@ class HeadlessDreamTexture(bpy.types.Operator):
         args.update(headless_args)
         if headless_init_img is not None:
             args['use_init_img'] = True
-        if headless_prompt.prompt_structure == file_batch_structure.id:
+        if args['prompt_structure'] == file_batch_structure.id:
             args['prompt'] = [line.body for line in scene.dream_textures_prompt_file.lines if len(line.body.strip()) > 0]
         args['init_img'] = init_img_path
-        if headless_prompt.use_init_img_color:
+        if args['use_init_img_color']:
             args['init_color'] = init_img_path
-        if headless_prompt.backend == BackendTarget.STABILITY_SDK.name:
+        if args['backend'] == BackendTarget.STABILITY_SDK.name:
             args['dream_studio_key'] = context.preferences.addons[StableDiffusionPreferences.bl_idname].preferences.dream_studio_key
 
         def step_callback(step, width=None, height=None, shared_memory_name=None):
@@ -257,7 +257,7 @@ class HeadlessDreamTexture(bpy.types.Operator):
             global headless_image_callback
             info() # clear variable
             nonlocal received_noncolorized
-            if headless_prompt.use_init_img and headless_prompt.use_init_img_color and not received_noncolorized:
+            if args['use_init_img'] and args['use_init_img_color'] and not received_noncolorized:
                 received_noncolorized = True
                 return
             received_noncolorized = False


### PR DESCRIPTION
A regression was introduced when color correction was added, causing the render pass to use it when it shouldn't be, and other odd bugs cascading such as the frontend during OCIO inversion receiving that color corrected image while its backend crashes attempting to open an already closed shared_memory object.

These changes make sure that the render pass does not use the prompt_to_image color correction and keeps later stages from running until the previous one is entirely completed to prevent race conditions.