### PR TITLE
Add link to video tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@
 * Run the models on your machine to iterate without slowdowns from a service
 
 # Installation
-Download the [latest release](https://github.com/carson-katri/dream-textures/releases/tag/0.0.7) and follow the instructions there to get up and running.
+Download the [latest release](https://github.com/carson-katri/dream-textures/releases/latest) and follow the instructions there to get up and running.
 
 > On macOS, it is possible you will run into a quarantine issue with the dependencies. To work around this, run the following command in the app `Terminal`: `xattr -r -d com.apple.quarantine ~/Library/Application\ Support/Blender/3.3/scripts/addons/dream_textures/.python_dependencies`. This will allow the PyTorch `.dylib`s and `.so`s to load without having to manually allow each one in System Preferences.
+
+If you want a visual guide to installation, see this video tutorial from Ashlee Martino-Tarr: https://youtu.be/kEcr8cNmqZk
+> Ensure you always install the [latest version](https://github.com/carson-katri/dream-textures/releases/latest) of the add-on if any guides become out of date.
 
 # Usage
 


### PR DESCRIPTION
Adds a link to a video tutorial that explains the setup process, and fixes a link to 0.0.7 to point to 0.0.8. This is the most accurate video tutorial I have seen for installation, but if anyone knows of other accurate tutorials I can link them as well.