### PR TITLE
Linux Fixes

### DIFF
--- a/generator_process/__init__.py
+++ b/generator_process/__init__.py
@@ -137,7 +137,9 @@ class Backend():
         self.intent_backends = {}
         self.stdin = sys.stdin.buffer
         self.stdout = sys.stdout.buffer
-        sys.stdout = open(os.devnull, 'w') # prevent stable diffusion logs from breaking ipc
+        # stdin and stdout are piped for ipc, they should not be accessed through usual methods
+        # stdout can be redirected to stderr so it's still visible within the parent process's console
+        sys.stdout = sys.stderr
         self.stderr = sys.stderr
         self.shared_memory = None
         self.stop_requested = False

--- a/generator_process/__init__.py
+++ b/generator_process/__init__.py
@@ -323,6 +323,14 @@ def main():
         if args.backend == BackendTarget.LOCAL:
             from ldm.invoke import txt2mask
             txt2mask.CLIPSEG_WEIGHTS = CLIPSEG_WEIGHTS_PATH
+        
+        try:
+            import certifi
+            os.environ["SSL_CERT_FILE"] = certifi.where()
+            using_certifi = True
+        except ModuleNotFoundError:
+            using_certifi = False
+        print(f"Using certifi: {using_certifi}")
 
         back.thread.start()
         back.main_loop()

--- a/generator_process/intents/prompt_to_image.py
+++ b/generator_process/intents/prompt_to_image.py
@@ -58,10 +58,6 @@ def prompt_to_image(self):
             self.send_action(Action.STEP_NO_SHOW, step=step)
 
     def preload_models():
-        cert_file = os.environ.get("SSL_CERT_FILE", None)
-        import certifi
-        os.environ["SSL_CERT_FILE"] = certifi.where()
-
         tqdm = None
         try:
             from huggingface_hub.utils.tqdm import tqdm as hfh_tqdm
@@ -115,10 +111,6 @@ def prompt_to_image(self):
         CLIPDensePredT(version='ViT-B/16', reduce_dim=64)
 
         tqdm.update = old_update
-        if cert_file:
-            os.environ["SSL_CERT_FILE"] = cert_file
-        else:
-            del os.environ["SSL_CERT_FILE"]
     
     from transformers.utils.hub import TRANSFORMERS_CACHE
     model_paths = {'bert-base-uncased', 'openai--clip-vit-large-patch14'}

--- a/generator_process/intents/prompt_to_image.py
+++ b/generator_process/intents/prompt_to_image.py
@@ -58,6 +58,10 @@ def prompt_to_image(self):
             self.send_action(Action.STEP_NO_SHOW, step=step)
 
     def preload_models():
+        cert_file = os.environ.get("SSL_CERT_FILE", None)
+        import certifi
+        os.environ["SSL_CERT_FILE"] = certifi.where()
+
         tqdm = None
         try:
             from huggingface_hub.utils.tqdm import tqdm as hfh_tqdm
@@ -98,23 +102,7 @@ def prompt_to_image(self):
         self.send_info("Preloading `kornia` requirements")
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', category=DeprecationWarning)
-            from urllib.error import URLError
-            from ssl import SSLCertVerificationError
-            try:
-                import kornia
-            except URLError as e:
-                if isinstance(e.reason, SSLCertVerificationError):
-                    print('Encountered SSLCertVerificationError while importing kornia.', file=sys.stderr)
-                    print('Attempting to download checkpoint_liberty_with_aug.pth via requests instead.', file=sys.stderr)
-                    # For some reason requests and urllib use different certs, doubt it'll 100% fix this case though
-                    import requests
-                    res = requests.get(r"https://github.com/DagnyT/hardnet/raw/master/pretrained/train_liberty_with_aug/checkpoint_liberty_with_aug.pth")
-                    res.raise_for_status()
-                    with open(os.path.expanduser(r"~/.cache/torch/hub/checkpoints/checkpoint_liberty_with_aug.pth"), 'wb') as f:
-                        f.write(res.content)
-                    import kornia
-                else:
-                    raise
+            import kornia
 
         start_preloading("CLIP")
         clip_version = 'openai/clip-vit-large-patch14'
@@ -127,6 +115,10 @@ def prompt_to_image(self):
         CLIPDensePredT(version='ViT-B/16', reduce_dim=64)
 
         tqdm.update = old_update
+        if cert_file:
+            os.environ["SSL_CERT_FILE"] = cert_file
+        else:
+            del os.environ["SSL_CERT_FILE"]
     
     from transformers.utils.hub import TRANSFORMERS_CACHE
     model_paths = {'bert-base-uncased', 'openai--clip-vit-large-patch14'}

--- a/operators/install_dependencies.py
+++ b/operators/install_dependencies.py
@@ -40,7 +40,7 @@ def install_pip(method = PipInstall.STANDARD):
                 whl = package.wheel_path
             wheels[name] = whl
         pip_whl = os.path.join(wheels['pip'], 'pip')
-        subprocess.run([sys.executable, pip_whl, "install", *wheels.values(), "--upgrade", "--no-index", "--no-deps", "--no-cache-dir", "--target", absolute_path(".python_dependencies")])
+        subprocess.run([sys.executable, pip_whl, "install", *wheels.values(), "--upgrade", "--no-index", "--no-deps", "--no-cache-dir", "--target", absolute_path(".python_dependencies")], check=True)
         return
     
     # STANDARD or USER_SITE

--- a/operators/install_dependencies.py
+++ b/operators/install_dependencies.py
@@ -1,7 +1,6 @@
 import bpy
 import os
 import sys
-import importlib
 import sysconfig
 import subprocess
 import requests
@@ -22,12 +21,18 @@ def install_pip():
 
     try:
         # Check if pip is already installed
-        subprocess.run([sys.executable, "-m", "pip", "--version"], check=True)
+        subprocess.run([sys.executable, "-s", "-m", "pip", "--version"], check=True)
     except subprocess.CalledProcessError:
+        no_user = os.environ.get("PYTHONNOUSERSITE", None)
+        os.environ["PYTHONNOUSERSITE"] = "1"
         import ensurepip
 
         ensurepip.bootstrap()
         os.environ.pop("PIP_REQ_TRACKER", None)
+        if no_user:
+            os.environ["PYTHONNOUSERSITE"] = no_user
+        else:
+            del os.environ["PYTHONNOUSERSITE"]
 
 def install_and_import_requirements(requirements_txt=None):
     """

--- a/operators/install_dependencies.py
+++ b/operators/install_dependencies.py
@@ -82,6 +82,4 @@ class InstallDependencies(bpy.types.Operator):
             self.report({"ERROR"}, str(err))
             return {"CANCELLED"}
 
-        subprocess.run([sys.executable, absolute_path("stable_diffusion/scripts/preload_models.py")], check=True, cwd=absolute_path("stable_diffusion/"))
-
         return {"FINISHED"}

--- a/operators/install_dependencies.py
+++ b/operators/install_dependencies.py
@@ -93,7 +93,7 @@ def get_pip_install():
         return PipInstall.USER_SITE
 
 
-def install_and_import_requirements(requirements_txt=None, pip_install=False):
+def install_and_import_requirements(requirements_txt=None, pip_install=PipInstall.STANDARD):
     """
     Installs all modules in the 'requirements.txt' file.
     """

--- a/preferences.py
+++ b/preferences.py
@@ -104,56 +104,56 @@ class StableDiffusionPreferences(bpy.types.AddonPreferences):
 
         if not weights_installed:
             layout.label(text="Complete the following steps to finish setting up the addon:")
-
-        if len(os.listdir(absolute_path(".python_dependencies"))) < 2:
-            missing_sd_box = layout.box()
-            missing_sd_box.label(text="Dependencies Missing", icon="ERROR")
-            missing_sd_box.label(text="You've likely downloaded source instead of release by accident.")
-            missing_sd_box.label(text="Follow the instructions to install for your platform.")
-            missing_sd_box.operator(OpenLatestVersion.bl_idname, text="Download Latest Release")
-            return
-
-        has_local = len(os.listdir(absolute_path("stable_diffusion"))) > 0
-        if has_local:
-            dependencies_box = layout.box()
-            dependencies_box.label(text="Dependencies Located", icon="CHECKMARK")
-            dependencies_box.label(text="All dependencies (except for model weights) are included in the release.")
-
-            model_weights_box = layout.box()
-            model_weights_box.label(text="Setup Model Weights", icon="SETTINGS")
-            if weights_installed:
-                model_weights_box.label(text="Model weights setup successfully.", icon="CHECKMARK")
-            else:
-                model_weights_box.label(text="The model weights are not distributed with the addon.")
-                model_weights_box.label(text="Follow the steps below to download and install them.")
-                model_weights_box.label(text="1. Download the file 'sd-v1-4.ckpt'")
-                model_weights_box.operator(OpenHuggingFace.bl_idname, icon="URL")
-                model_weights_box.label(text="2. Select the downloaded weights to install.")
-            model_weights_box.operator(ImportWeights.bl_idname, text="Import Model Weights", icon="IMPORT")
-            model_weights_box.template_list("UI_UL_list", "dream_textures_weights", self, "weights", self, "active_weights")
-            model_weights_box.operator(DeleteSelectedWeights.bl_idname, text="Delete Selected Weights", icon="X")
         
-        dream_studio_box = layout.box()
-        dream_studio_box.label(text=f"DreamStudio{' (Optional)' if has_local else ''}", icon="HIDE_OFF")
-        dream_studio_box.label(text=f"Link to your DreamStudio account to run in the cloud{' instead of locally.' if has_local else '.'}")
-        key_row = dream_studio_box.row()
-        key_row.prop(self, "dream_studio_key", text="Key")
-        key_row.operator(OpenDreamStudio.bl_idname, text="Find Your Key", icon="KEYINGSET")
+        has_dependencies = len(os.listdir(absolute_path(".python_dependencies"))) > 2
+        if has_dependencies:
+            has_local = len(os.listdir(absolute_path("stable_diffusion"))) > 0
+            if has_local:
+                dependencies_box = layout.box()
+                dependencies_box.label(text="Dependencies Located", icon="CHECKMARK")
+                dependencies_box.label(text="All dependencies (except for model weights) are included in the release.")
 
-        if weights_installed or len(self.dream_studio_key) > 0:
-            complete_box = layout.box()
-            complete_box.label(text="Addon Setup Complete", icon="CHECKMARK")
-            complete_box.label(text="To locate the interface:")
-            complete_box.label(text="1. Open an Image Editor or Shader Editor space")
-            complete_box.label(text="2. Enable 'View' > 'Sidebar'")
-            complete_box.label(text="3. Select the 'Dream' tab")
-        
-        if default_presets_missing():
-            presets_box = layout.box()
-            presets_box.label(text="Default Presets", icon="PRESET")
-            presets_box.label(text="It looks like you removed some of the default presets.")
-            presets_box.label(text="You can restore them here.")
-            presets_box.operator(RestoreDefaultPresets.bl_idname, icon="RECOVER_LAST")
+                model_weights_box = layout.box()
+                model_weights_box.label(text="Setup Model Weights", icon="SETTINGS")
+                if weights_installed:
+                    model_weights_box.label(text="Model weights setup successfully.", icon="CHECKMARK")
+                else:
+                    model_weights_box.label(text="The model weights are not distributed with the addon.")
+                    model_weights_box.label(text="Follow the steps below to download and install them.")
+                    model_weights_box.label(text="1. Download the file 'sd-v1-4.ckpt'")
+                    model_weights_box.operator(OpenHuggingFace.bl_idname, icon="URL")
+                    model_weights_box.label(text="2. Select the downloaded weights to install.")
+                model_weights_box.operator(ImportWeights.bl_idname, text="Import Model Weights", icon="IMPORT")
+                model_weights_box.template_list("UI_UL_list", "dream_textures_weights", self, "weights", self, "active_weights")
+                model_weights_box.operator(DeleteSelectedWeights.bl_idname, text="Delete Selected Weights", icon="X")
+            
+            dream_studio_box = layout.box()
+            dream_studio_box.label(text=f"DreamStudio{' (Optional)' if has_local else ''}", icon="HIDE_OFF")
+            dream_studio_box.label(text=f"Link to your DreamStudio account to run in the cloud{' instead of locally.' if has_local else '.'}")
+            key_row = dream_studio_box.row()
+            key_row.prop(self, "dream_studio_key", text="Key")
+            key_row.operator(OpenDreamStudio.bl_idname, text="Find Your Key", icon="KEYINGSET")
+
+            if weights_installed or len(self.dream_studio_key) > 0:
+                complete_box = layout.box()
+                complete_box.label(text="Addon Setup Complete", icon="CHECKMARK")
+                complete_box.label(text="To locate the interface:")
+                complete_box.label(text="1. Open an Image Editor or Shader Editor space")
+                complete_box.label(text="2. Enable 'View' > 'Sidebar'")
+                complete_box.label(text="3. Select the 'Dream' tab")
+            
+            if default_presets_missing():
+                presets_box = layout.box()
+                presets_box.label(text="Default Presets", icon="PRESET")
+                presets_box.label(text="It looks like you removed some of the default presets.")
+                presets_box.label(text="You can restore them here.")
+                presets_box.operator(RestoreDefaultPresets.bl_idname, icon="RECOVER_LAST")
+        else:
+            missing_dependencies_box = layout.box()
+            missing_dependencies_box.label(text="Dependencies Missing", icon="ERROR")
+            missing_dependencies_box.label(text="You've likely downloaded source instead of release by accident.")
+            missing_dependencies_box.label(text="Follow the instructions to install for your platform.")
+            missing_dependencies_box.operator(OpenLatestVersion.bl_idname, text="Download Latest Release")
         
         contributors_box = layout.box()
         contributors_box.label(text="Contributors", icon="COMMUNITY")
@@ -165,8 +165,7 @@ class StableDiffusionPreferences(bpy.types.AddonPreferences):
             developer_box.label(text="Development Tools", icon="CONSOLE")
             developer_box.label(text="This section is for addon development only. You are seeing this because you have 'Developer Extras' enabled.")
             developer_box.label(text="Do not use any operators in this section unless you are setting up a development environment.")
-            already_installed = len(os.listdir(absolute_path(".python_dependencies"))) > 0
-            if already_installed:
+            if has_dependencies:
                 warn_box = developer_box.box()
                 warn_box.label(text="Dependencies already installed. Only install below if you developing the addon", icon="CHECKMARK")
             developer_box.prop(context.scene, 'dream_textures_requirements_path')


### PR DESCRIPTION
Main included fix is for `SSLCertVerificationError` while importing `kornia`. Made it so the base `ssl` module can use `certifi`'s `cacert.pem` file. The Blender 3.3.1 version I used has a broken `ssl` module that points to certs which do not exist, and I doubt this is the only version with the same problem.
```python
>>> import ssl
>>> ssl.get_default_verify_paths()
DefaultVerifyPaths(
	cafile=None,
	capath=None,
	openssl_cafile_env='SSL_CERT_FILE',
	openssl_cafile='/home/sybren/buildbot-builder/linux_glibc217_x86_64_cmake/build_deps/deps/Release/ssl/cert.pem',
	openssl_capath_env='SSL_CERT_DIR',
	openssl_capath='/home/sybren/buildbot-builder/linux_glibc217_x86_64_cmake/build_deps/deps/Release/ssl/certs'
)
>>> import os
>>> import certifi
>>> os.environ['SSL_CERT_FILE'] = certifi.where()
>>> ssl.get_default_verify_paths()
DefaultVerifyPaths(
	cafile='/home/nullsense/blender/blender-3.3.1/3.3/python/lib/python3.10/site-packages/certifi/cacert.pem',
	capath=None,
	openssl_cafile_env='SSL_CERT_FILE',
	openssl_cafile='/home/sybren/buildbot-builder/linux_glibc217_x86_64_cmake/build_deps/deps/Release/ssl/cert.pem',
	openssl_capath_env='SSL_CERT_DIR',
	openssl_capath='/home/sybren/buildbot-builder/linux_glibc217_x86_64_cmake/build_deps/deps/Release/ssl/certs'
)
```
After the change `urllib` won't fail on every https request and correctly downloads `checkpoint_liberty_with_aug.pth`. If there ends up being more issues with SSL verification it's likely fixable by updating the `certifi` module via pip.


Had an issue where for some reason pip was installed into the user site packages so ensurepip would not install it to Blender's `site-packages` directory. Made it so that should no longer accidentally happen.


Removed model preloading from the install dependencies operator since that's taken care of in `prompt_to_image.py` and just errors here.


Made it so the subprocess's stdout isn't discarded and is instead the same as stderr so it's still visible in the terminal. The model loading step will just print its error information so it was getting completely lost and leading to harder to debug issues.


This PR is not ready to merge yet since I'd like to spend more time trying to find more bugs to fix.