### PR TITLE
Add support for inpainting model and other model types import

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -43,6 +43,7 @@ from .property_groups.dream_prompt import DreamPrompt
 from .operators.upscale import upscale_options
 from .preferences import StableDiffusionPreferences
 from .ui.presets import register_default_presets
+from .absolute_path import REAL_ESRGAN_WEIGHTS_PATH
 
 requirements_path_items = (
     # Use the old version of requirements-win.txt to fix installation issues with Blender + PyTorch 1.12.1
@@ -82,6 +83,7 @@ def register():
     bpy.types.Scene.dream_textures_viewport_enabled = BoolProperty(name="Viewport Enabled", default=False)
     bpy.types.Scene.dream_textures_render_properties_enabled = BoolProperty(default=False)
     bpy.types.Scene.dream_textures_render_properties_prompt = PointerProperty(type=DreamPrompt)
+    bpy.types.Scene.dream_textures_upscale_model = bpy.props.EnumProperty(name="Model", items=lambda self, context: [(f, f, '', i) for i, f in enumerate(filter(lambda f: f.endswith('.pth'), os.listdir(REAL_ESRGAN_WEIGHTS_PATH)))])
     bpy.types.Scene.dream_textures_upscale_outscale = bpy.props.EnumProperty(name="Target Size", items=upscale_options)
     bpy.types.Scene.dream_textures_upscale_full_precision = bpy.props.BoolProperty(name="Full Precision", default=True)
     bpy.types.Scene.dream_textures_upscale_seamless = bpy.props.BoolProperty(name="Seamless", default=False)

--- a/absolute_path.py
+++ b/absolute_path.py
@@ -9,5 +9,7 @@ def absolute_path(component):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), component)
 
 WEIGHTS_PATH = absolute_path("weights/stable-diffusion-v1.4/")
-REAL_ESRGAN_WEIGHTS_PATH = absolute_path("weights/realesrgan/realesr-general-x4v3.pth")
-CLIPSEG_WEIGHTS_PATH = absolute_path("weights/clipseg/rd64-uni.pth")
+VAE_WEIGHTS_PATH = absolute_path("weights/vae/")
+INPAINTING_WEIGHTS_PATH = absolute_path("weights/stable-diffusion-inpainting/")
+REAL_ESRGAN_WEIGHTS_PATH = absolute_path("weights/realesrgan/")
+CLIPSEG_WEIGHTS_PATH = absolute_path("weights/clipseg/")

--- a/classes.py
+++ b/classes.py
@@ -6,7 +6,7 @@ from .operators.inpaint_area_brush import InpaintAreaBrushActivated
 from .operators.upscale import Upscale
 from .property_groups.dream_prompt import DreamPrompt
 from .ui.panels import dream_texture, history, upscaling, render_properties
-from .preferences import OpenHuggingFace, OpenContributors, StableDiffusionPreferences, OpenDreamStudio, ImportWeights, WeightsFile, DeleteSelectedWeights
+from .preferences import OpenHuggingFace, OpenContributors, StableDiffusionPreferences, OpenDreamStudio, ImportWeights, WeightsFile, DeleteSelectedWeights, PREFERENCES_UL_WeightsFileList
 
 from .ui.presets import DREAM_PT_AdvancedPresets, DREAM_MT_AdvancedPresets, AddAdvancedPreset, RestoreDefaultPresets
 
@@ -44,6 +44,7 @@ CLASSES = (
 )
 
 PREFERENCE_CLASSES = (
+                      PREFERENCES_UL_WeightsFileList,
                       DeleteSelectedWeights,
                       WeightsFile,
                       DreamPrompt,

--- a/generator_process/__init__.py
+++ b/generator_process/__init__.py
@@ -137,7 +137,8 @@ class Backend():
         self.intent_backends = {}
         self.stdin = sys.stdin.buffer
         self.stdout = sys.stdout.buffer
-        sys.stdout = open(os.devnull, 'w') # prevent stable diffusion logs from breaking ipc
+        # sys.stdout = open(os.devnull, 'w') # prevent stable diffusion logs from breaking ipc
+        sys.stdout = sys.stderr
         self.stderr = sys.stderr
         self.shared_memory = None
         self.stop_requested = False

--- a/generator_process/intents/upscale.py
+++ b/generator_process/intents/upscale.py
@@ -35,6 +35,7 @@ def upscale(self):
     from realesrgan import RealESRGANer
     from realesrgan.archs.srvgg_arch import SRVGGNetCompact
     from torch import nn
+    import os
     while True:
         image = cv2.imread(args['input'], cv2.IMREAD_UNCHANGED)
         real_esrgan_model = SRVGGNetCompact(num_in_ch=3, num_out_ch=3, num_feat=64, num_conv=32, upscale=4, act_type='prelu')
@@ -46,7 +47,7 @@ def upscale(self):
         self.send_info("Loading Upsampler")
         upsampler = RealESRGANer(
             scale=netscale,
-            model_path=REAL_ESRGAN_WEIGHTS_PATH,
+            model_path=os.path.join(REAL_ESRGAN_WEIGHTS_PATH, args['model']),
             model=real_esrgan_model,
             tile=0,
             tile_pad=10,

--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -207,21 +207,16 @@ class HeadlessDreamTexture(bpy.types.Operator):
 
         def save_temp_image(img, path=None):
             path = path if path is not None else tempfile.NamedTemporaryFile().name
+            
+            orig_path = img.filepath_raw
+            orig_format = img.file_format
 
-            settings = scene.render.image_settings
-            file_format = settings.file_format
-            mode = settings.color_mode
-            depth = settings.color_depth
+            img.filepath_raw = path
+            img.file_format = 'PNG'
+            img.save()
 
-            settings.file_format = 'PNG'
-            settings.color_mode = 'RGBA'
-            settings.color_depth = '8'
-
-            img.save_render(path)
-
-            settings.file_format = file_format
-            settings.color_mode = mode
-            settings.color_depth = depth
+            img.filepath_raw = orig_path
+            img.file_format = orig_format
 
             return path
 

--- a/operators/upscale.py
+++ b/operators/upscale.py
@@ -121,6 +121,7 @@ class Upscale(bpy.types.Operator):
         generator = GeneratorProcess.shared()
 
         args = {
+            'model': context.scene.dream_textures_upscale_model,
             'input': input_image_path,
             'name': input_image.name,
             'outscale': int(context.scene.dream_textures_upscale_outscale),

--- a/ui/panels/dream_texture.py
+++ b/ui/panels/dream_texture.py
@@ -7,7 +7,7 @@ import shutil
 
 from ...generator_process.registrar import BackendTarget
 
-from ...absolute_path import CLIPSEG_WEIGHTS_PATH
+from ...absolute_path import CLIPSEG_WEIGHTS_PATH, INPAINTING_WEIGHTS_PATH
 from ..presets import DREAM_PT_AdvancedPresets
 from ...pil_to_image import *
 from ...prompt_engineering import *
@@ -49,6 +49,11 @@ def dream_texture_panels():
                     layout.prop(context.scene.dream_textures_prompt, "backend")
                 if context.scene.dream_textures_prompt.backend == BackendTarget.LOCAL.name:
                     layout.prop(context.scene.dream_textures_prompt, 'model')
+                    layout.prop(context.scene.dream_textures_prompt, 'vae')
+                    if context.scene.dream_textures_prompt.model.startswith(INPAINTING_WEIGHTS_PATH) and not context.scene.dream_textures_prompt.use_init_img:
+                        box = layout.box()
+                        box.label(text="Inpainting Model Selected", icon="ERROR")
+                        box.label(text="Source image is not enabled, but an inpainting model was selected.")
 
                 if is_force_show_download():
                     layout.operator(OpenLatestVersion.bl_idname, icon="IMPORT", text="Download Latest Release")

--- a/ui/panels/upscaling.py
+++ b/ui/panels/upscaling.py
@@ -73,6 +73,7 @@ def upscaling_panels():
                     layout.operator(OpenRealESRGANWeightsDirectory.bl_idname, icon="IMPORT")
                 layout = layout.column()
                 layout.enabled = os.path.exists(REAL_ESRGAN_WEIGHTS_PATH)
+                layout.prop(context.scene, "dream_textures_upscale_model")
                 layout.prop(context.scene, "dream_textures_upscale_outscale")
                 layout.prop(context.scene, "dream_textures_upscale_full_precision")
                 layout.prop(context.scene, "dream_textures_upscale_seamless")

--- a/weights/stable-diffusion-embeddings/.gitignore
+++ b/weights/stable-diffusion-embeddings/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/weights/stable-diffusion-inpainting/.gitignore
+++ b/weights/stable-diffusion-inpainting/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/weights/vae/.gitignore
+++ b/weights/vae/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Resolves #358
The model import UI was refactored to allow for various types of weights to be imported:
<img width="485" alt="Screenshot 2022-11-05 at 1 58 46 PM" src="https://user-images.githubusercontent.com/13581484/200134398-18255aa8-f07a-46ef-a6da-1b0f98193c70.png">
When importing, you can select which type of weights file is being imported in the sidebar.
<img width="826" alt="Screenshot 2022-11-05 at 1 59 44 PM" src="https://user-images.githubusercontent.com/13581484/200134442-e0682203-9a32-4c64-8162-3142b54479df.png">
