### PR TITLE
Show the seed in history to easier match generated images to their promts

### DIFF
--- a/operators/view_history.py
+++ b/operators/view_history.py
@@ -10,11 +10,13 @@ class SCENE_UL_HistoryList(bpy.types.UIList):
         if self.layout_type in {'DEFAULT', 'COMPACT'}:
             if item.prompt_structure_token_subject == "SCENE_UL_HistoryList_header":
                 layout.label(text="Subject")
+                layout.label(text="Seed")
                 layout.label(text="Size")
                 layout.label(text="Steps")
                 layout.label(text="Sampler")
             else:
                 layout.label(text=item.get_prompt_subject(), translate=False, icon_value=icon)
+                layout.label(text=f"{item.seed}", translate=False)
                 layout.label(text=f"{item.width}x{item.height}", translate=False)
                 layout.label(text=f"{item.steps} steps", translate=False)
                 layout.label(text=next(x for x in sampler_options if x[0] == item.sampler_name)[1], translate=False)


### PR DESCRIPTION
When creating images, their are stored as a datablock with only the seed as name. Thus it would be very helpful to also have the seed in the history to make it easier going back to promt and fine-tuning.

![grafik](https://user-images.githubusercontent.com/2581621/202164354-23103063-0140-4a9a-b3cb-84155b0a28f2.png)
