### PR TITLE
UI enhancement: When recalling a promt, open the corresponding image …

### DIFF
--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -98,7 +98,7 @@ class DreamTexture(bpy.types.Operator):
                 scene.dream_textures_prompt.seed = str(seed) # update property in case seed was sourced randomly or from hash
                 # create a hash from the Blender image datablock to use as unique ID of said image and store it in the prompt history
                 # and as custom property of the image. Needs to be a string because the int from the hash function is too large
-                image_hash = str(hash(image))
+                image_hash = hashlib.sha256((np.array(image.pixels) * 255).tobytes()).hexdigest()
                 image['dream_textures_hash'] = image_hash
                 scene.dream_textures_prompt.hash = image_hash
                 history_entries[iteration].seed = str(seed)

--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -1,6 +1,7 @@
 import sys
 import bpy
 import os
+import hashlib
 import numpy as np
 from multiprocessing.shared_memory import SharedMemory
 

--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -96,8 +96,14 @@ class DreamTexture(bpy.types.Operator):
                     if area.type == 'IMAGE_EDITOR':
                         area.spaces.active.image = image
                 scene.dream_textures_prompt.seed = str(seed) # update property in case seed was sourced randomly or from hash
+                # create a hash from the Blender image datablock to use as unique ID of said image and store it in the prompt history
+                # and as custom property of the image. Needs to be a string because the int from the hash function is too large
+                image_hash = str(hash(image))
+                image['dream_textures_hash'] = image_hash
+                scene.dream_textures_prompt.hash = image_hash
                 history_entries[iteration].seed = str(seed)
                 history_entries[iteration].random_seed = False
+                history_entries[iteration].hash = image_hash
                 iteration += 1
         
         def view_step(step, width=None, height=None, shared_memory_name=None):

--- a/operators/view_history.py
+++ b/operators/view_history.py
@@ -41,20 +41,23 @@ class RecallHistoryEntry(bpy.types.Operator):
                 setattr(context.scene.dream_textures_prompt, prop, getattr(selection, prop))
             # when the seed of the promt is found in the available image datablocks, use that one in the open image editor
             # note: when there is more than one image with the seed in it's name, do nothing. Same when no image with that seed is available.
-            if prop == 'seed':
-                seed_string = str(getattr(selection, prop))
-                image_names_no_suffix = [i.name.split('.')[0] for i in bpy.data.images]
-                image_names_no_suffix_seed_count = image_names_no_suffix.count(seed_string)
-                if image_names_no_suffix_seed_count == 1:
-                    print("Image for seed " + seed_string + " is unique. Selecting image datablock.")
+            if prop == 'hash':
+                hash_string = str(getattr(selection, prop))
+                existing_image = None
+                # accessing custom properties for image datablocks in Blender is still a bit cumbersome
+                for i in bpy.data.images:
+                    try:
+                        # this will fail for images without the dream_textures_hash custom property
+                        if i['dream_textures_hash'] == hash_string:
+                            existing_image = i
+                            break
+                    except:
+                        continue
+                if existing_image != None:
                     for area in context.screen.areas:
                         if area.type != 'IMAGE_EDITOR':
                             continue
-                        area.spaces.active.image = bpy.data.images[seed_string]
-                elif image_names_no_suffix_seed_count > 1:
-                    self.report({'INFO'}, "More than one image found for seed " + seed_string + ". Not changing image editor contents.")
-                elif image_names_no_suffix_seed_count == 0:
-                    self.report({'INFO'}, "No image found for seed " + seed_string + ". Not changing image editor contents.")
+                        area.spaces.active.image = existing_image
 
         return {"FINISHED"}
 

--- a/operators/view_history.py
+++ b/operators/view_history.py
@@ -39,6 +39,22 @@ class RecallHistoryEntry(bpy.types.Operator):
         for prop in selection.__annotations__.keys():
             if hasattr(context.scene.dream_textures_prompt, prop):
                 setattr(context.scene.dream_textures_prompt, prop, getattr(selection, prop))
+            # when the seed of the promt is found in the available image datablocks, use that one in the open image editor
+            # note: when there is more than one image with the seed in it's name, do nothing. Same when no image with that seed is available.
+            if prop == 'seed':
+                seed_string = str(getattr(selection, prop))
+                image_names_no_suffix = [i.name.split('.')[0] for i in bpy.data.images]
+                image_names_no_suffix_seed_count = image_names_no_suffix.count(seed_string)
+                if image_names_no_suffix_seed_count == 1:
+                    print("Image for seed " + seed_string + " is unique. Selecting image datablock.")
+                    for area in context.screen.areas:
+                        if area.type != 'IMAGE_EDITOR':
+                            continue
+                        area.spaces.active.image = bpy.data.images[seed_string]
+                elif image_names_no_suffix_seed_count > 1:
+                    self.report({'INFO'}, "More than one image found for seed " + seed_string + ". Not changing image editor contents.")
+                elif image_names_no_suffix_seed_count == 0:
+                    self.report({'INFO'}, "No image found for seed " + seed_string + ". Not changing image editor contents.")
 
         return {"FINISHED"}
 

--- a/property_groups/dream_prompt.py
+++ b/property_groups/dream_prompt.py
@@ -121,6 +121,9 @@ attributes = {
     "outpaint_bottom": IntProperty(name="Bottom", default=64, step=64, min=0),
     "outpaint_left": IntProperty(name="Left", default=64, step=64, min=0),
     "outpaint_blend": IntProperty(name="Blend", description="Gaussian blur amount to apply to the extended area", default=16, min=0),
+
+    # Resulting image
+    "dream_textures_hash": StringProperty(name="Result Hash"),
 }
 
 def map_structure_token_items(value):

--- a/property_groups/dream_prompt.py
+++ b/property_groups/dream_prompt.py
@@ -123,7 +123,7 @@ attributes = {
     "outpaint_blend": IntProperty(name="Blend", description="Gaussian blur amount to apply to the extended area", default=16, min=0),
 
     # Resulting image
-    "dream_textures_hash": StringProperty(name="Result Hash"),
+    "hash": StringProperty(name="Image Hash"),
 }
 
 def map_structure_token_items(value):


### PR DESCRIPTION
…in the image editor when there is an image with the same name as the seed value in the promt.

When there is an image datablock with the same name as the seed from the promt to be recalled, open it in the image editor. When there is more than one datablock with the seed in it's name (like 12345.001, 12345.002 etc.) do not change the image open in the image editor and give a notification to the user.

https://user-images.githubusercontent.com/2581621/203351255-47cb1dba-d63b-4fe0-aeb1-a415fdd8af01.mp4

