### PR TITLE
Always use spawn multiprocessing context

### DIFF
--- a/generator_process/actor.py
+++ b/generator_process/actor.py
@@ -1,4 +1,4 @@
-from multiprocessing import Queue, Process, Lock, current_process
+from multiprocessing import Queue, Process, Lock, current_process, get_context
 import multiprocessing.synchronize
 import enum
 import traceback
@@ -225,7 +225,7 @@ class Actor:
         """
         match self.context:
             case ActorContext.FRONTEND:
-                self.process = Process(target=_start_backend, args=(self.__class__, self._message_queue, self._response_queue), name="__actor__", daemon=True)
+                self.process = get_context('spawn').Process(target=_start_backend, args=(self.__class__, self._message_queue, self._response_queue), name="__actor__", daemon=True)
                 self.process.start()
             case ActorContext.BACKEND:
                 self._backend_loop()

--- a/generator_process/actor.py
+++ b/generator_process/actor.py
@@ -198,8 +198,8 @@ class Actor:
 
     def __init__(self, context: ActorContext, message_queue: Queue = None, response_queue: Queue = None):
         self.context = context
-        self._message_queue = message_queue if message_queue is not None else Queue(maxsize=1)
-        self._response_queue = response_queue if response_queue is not None else Queue(maxsize=1)
+        self._message_queue = message_queue if message_queue is not None else get_context('spawn').Queue(maxsize=1)
+        self._response_queue = response_queue if response_queue is not None else get_context('spawn').Queue(maxsize=1)
         self._setup()
         self.__class__._shared_instance = self
     


### PR DESCRIPTION
Unix based systems use the multiprocessing context `fork` whereas Windows and macOS systems use `spawn` by default. This is leading to the `_load_dependencies()` function never being called so most of the backend is non-functional.

Fixes #430 