### PR TITLE
Reset depth test mode, debug messages

### DIFF
--- a/operators/project.py
+++ b/operators/project.py
@@ -272,6 +272,7 @@ def draw_facing_map(width, height, context, matrix, projection_matrix):
     with offscreen.bind():
         fb = gpu.state.active_framebuffer_get()
         fb.clear(color=(0.0, 0.0, 0.0, 0.0))
+        depth_test_setting = gpu.state.depth_test_get()
         gpu.state.depth_test_set('LESS_EQUAL')
         gpu.state.depth_mask_set(True)
         with gpu.matrix.push_pop():
@@ -306,6 +307,7 @@ def draw_facing_map(width, height, context, matrix, projection_matrix):
                 )
                 batch.draw(shader)
         facing = np.array(fb.read_color(0, 0, width, height, 4, 0, 'FLOAT').to_list())
+        gpu.state.depth_test_set(depth_test_setting)
     offscreen.free()
     return facing
 
@@ -588,6 +590,7 @@ class ProjectDreamTexture(bpy.types.Operator):
                 projected_maps.append(res)
             prev_projected_maps.clear()
             # Blend each perspective together.
+            print("Blending perspectives")
             for i, perspective in enumerate(context.scene.dream_textures_project_perspectives):
                 for j, perspective_b in enumerate(context.scene.dream_textures_project_perspectives):
                     if i == j:
@@ -633,5 +636,7 @@ class ProjectDreamTexture(bpy.types.Operator):
                 texture.pixels[:] = map.ravel()
                 texture.update()
             image_texture_node.image = texture
+
+        print("Finished generating")
 
         return {'FINISHED'}

--- a/operators/project_helpers/draw_projected.py
+++ b/operators/project_helpers/draw_projected.py
@@ -53,6 +53,7 @@ def draw_projected_map(context, matrix, projection_matrix, target_matrix, target
     with offscreen.bind():
         fb = gpu.state.active_framebuffer_get()
         fb.clear(color=(0.0, 0.0, 0.0, 0.0))
+        depth_test_setting = gpu.state.depth_test_get()
         gpu.state.depth_test_set('LESS_EQUAL')
         gpu.state.depth_mask_set(True)
         with gpu.matrix.push_pop():
@@ -90,6 +91,7 @@ def draw_projected_map(context, matrix, projection_matrix, target_matrix, target
                 batch.draw(shader)
         projected = np.array(fb.read_color(0, 0, width, height, 4, 0, 'FLOAT').to_list())
         # projected = np.interp(projected, [projected.min(), projected.max()], [image.min(), image.max()])
+        gpu.state.depth_test_set(depth_test_setting)
     offscreen.free()
     return projected
 


### PR DESCRIPTION
Reset depth test mode after drawing specific maps, add some debug messages for clarity.