### PR TITLE
Add segmentation ControlNet support

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -32,6 +32,7 @@ categories = [
     DreamTexturesNodeCategory("DREAM_TEXTURES_UTILITY", "Utilities", items = [
         nodeitems_utils.NodeItem(NodeMath.bl_idname),
         nodeitems_utils.NodeItem(NodeRandomValue.bl_idname),
+        nodeitems_utils.NodeItem(NodeRandomSeed.bl_idname),
         nodeitems_utils.NodeItem(NodeClamp.bl_idname),
     ]),
     DreamTexturesNodeCategory("DREAM_TEXTURES_ANNOTATIONS", "Annotations", items = [
@@ -83,6 +84,7 @@ def register():
 
     bpy.utils.register_class(NodeMath)
     bpy.utils.register_class(NodeRandomValue)
+    bpy.utils.register_class(NodeRandomSeed)
     bpy.utils.register_class(NodeClamp)
 
     nodeitems_utils.register_node_categories("DREAM_TEXTURES_CATEGORIES", categories)
@@ -117,6 +119,7 @@ def unregister():
     
     bpy.utils.unregister_class(NodeMath)
     bpy.utils.unregister_class(NodeRandomValue)
+    bpy.utils.unregister_class(NodeRandomSeed)
     bpy.utils.unregister_class(NodeClamp)
 
     nodeitems_utils.unregister_node_categories("DREAM_TEXTURES_CATEGORIES")

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -33,6 +33,7 @@ categories = [
         nodeitems_utils.NodeItem(NodeMath.bl_idname),
         nodeitems_utils.NodeItem(NodeRandomValue.bl_idname),
         nodeitems_utils.NodeItem(NodeRandomSeed.bl_idname),
+        nodeitems_utils.NodeItem(NodeSeed.bl_idname),
         nodeitems_utils.NodeItem(NodeClamp.bl_idname),
     ]),
     DreamTexturesNodeCategory("DREAM_TEXTURES_ANNOTATIONS", "Annotations", items = [
@@ -87,6 +88,7 @@ def register():
     bpy.utils.register_class(NodeMath)
     bpy.utils.register_class(NodeRandomValue)
     bpy.utils.register_class(NodeRandomSeed)
+    bpy.utils.register_class(NodeSeed)
     bpy.utils.register_class(NodeClamp)
 
     nodeitems_utils.register_node_categories("DREAM_TEXTURES_CATEGORIES", categories)
@@ -123,6 +125,7 @@ def unregister():
     bpy.utils.unregister_class(NodeMath)
     bpy.utils.unregister_class(NodeRandomValue)
     bpy.utils.unregister_class(NodeRandomSeed)
+    bpy.utils.unregister_class(NodeSeed)
     bpy.utils.unregister_class(NodeClamp)
 
     nodeitems_utils.unregister_node_categories("DREAM_TEXTURES_CATEGORIES")

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -39,6 +39,7 @@ categories = [
         nodeitems_utils.NodeItem(NodeAnnotationDepth.bl_idname),
         nodeitems_utils.NodeItem(NodeAnnotationOpenPose.bl_idname),
         nodeitems_utils.NodeItem(NodeAnnotationADE20K.bl_idname),
+        nodeitems_utils.NodeItem(NodeAnnotationViewport.bl_idname),
     ]),
     DreamTexturesNodeCategory("DREAM_TEXTURES_GROUP", "Group", items = [
         nodeitems_utils.NodeItem(bpy.types.NodeGroupOutput.__name__),
@@ -81,6 +82,7 @@ def register():
     bpy.utils.register_class(NodeAnnotationDepth)
     bpy.utils.register_class(NodeAnnotationOpenPose)
     bpy.utils.register_class(NodeAnnotationADE20K)
+    bpy.utils.register_class(NodeAnnotationViewport)
 
     bpy.utils.register_class(NodeMath)
     bpy.utils.register_class(NodeRandomValue)
@@ -116,6 +118,7 @@ def unregister():
     bpy.utils.unregister_class(NodeAnnotationDepth)
     bpy.utils.unregister_class(NodeAnnotationOpenPose)
     bpy.utils.unregister_class(NodeAnnotationADE20K)
+    bpy.utils.unregister_class(NodeAnnotationViewport)
     
     bpy.utils.unregister_class(NodeMath)
     bpy.utils.unregister_class(NodeRandomValue)

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -7,6 +7,7 @@ from .nodes.pipeline_nodes import *
 from .nodes.utility_nodes import *
 from .nodes.annotation_nodes import *
 from .annotations import openpose
+from .annotations import ade20k
 
 import bpy
 import nodeitems_utils
@@ -36,6 +37,7 @@ categories = [
     DreamTexturesNodeCategory("DREAM_TEXTURES_ANNOTATIONS", "Annotations", items = [
         nodeitems_utils.NodeItem(NodeAnnotationDepth.bl_idname),
         nodeitems_utils.NodeItem(NodeAnnotationOpenPose.bl_idname),
+        nodeitems_utils.NodeItem(NodeAnnotationADE20K.bl_idname),
     ]),
     DreamTexturesNodeCategory("DREAM_TEXTURES_GROUP", "Group", items = [
         nodeitems_utils.NodeItem(bpy.types.NodeGroupOutput.__name__),
@@ -56,6 +58,12 @@ def register():
         type=openpose.BoneOpenPoseData
     )
 
+    # ADE20K
+    bpy.utils.register_class(ade20k.ObjectADE20KData)
+    bpy.types.Object.dream_textures_ade20k = bpy.props.PointerProperty(
+        type=ade20k.ObjectADE20KData
+    )
+
     bpy.utils.register_class(DreamTexturesNodeTree)
     
     # Nodes
@@ -71,6 +79,7 @@ def register():
     
     bpy.utils.register_class(NodeAnnotationDepth)
     bpy.utils.register_class(NodeAnnotationOpenPose)
+    bpy.utils.register_class(NodeAnnotationADE20K)
 
     bpy.utils.register_class(NodeMath)
     bpy.utils.register_class(NodeRandomValue)
@@ -84,6 +93,10 @@ def unregister():
     bpy.utils.unregister_class(openpose.ArmatureOpenPoseData)
     del bpy.types.Bone.dream_textures_openpose
     bpy.utils.unregister_class(openpose.BoneOpenPoseData)
+
+    # ADE20K
+    del bpy.types.Object.dream_textures_ade20k
+    bpy.utils.unregister_class(ade20k.ObjectADE20KData)
 
     bpy.utils.unregister_class(DreamTexturesNodeTree)
     
@@ -100,6 +113,7 @@ def unregister():
 
     bpy.utils.unregister_class(NodeAnnotationDepth)
     bpy.utils.unregister_class(NodeAnnotationOpenPose)
+    bpy.utils.unregister_class(NodeAnnotationADE20K)
     
     bpy.utils.unregister_class(NodeMath)
     bpy.utils.unregister_class(NodeRandomValue)

--- a/engine/annotations/ade20k.py
+++ b/engine/annotations/ade20k.py
@@ -69,6 +69,7 @@ def render_ade20k_map(context, collection=None, invert=True):
                     draw_annotation(vertices, indices, color)
             result = np.array(fb.read_color(0, 0, width, height, 4, 0, 'FLOAT').to_list())
             result[:, :, 3] = 1
+        gpu.state.depth_test_set('NONE')
         offscreen.free()
         e.set()
     bpy.app.timers.register(_execute, first_interval=0)

--- a/engine/annotations/ade20k.py
+++ b/engine/annotations/ade20k.py
@@ -66,14 +66,13 @@ def render_ade20k_map(context, collection=None, invert=True):
                     
                     color = annotation_colors[object.dream_textures_ade20k.annotation]
 
-                    draw_annotation(vertices, indices, (color[0], color[1], color[2], 1))
+                    draw_annotation(vertices, indices, color)
             result = np.array(fb.read_color(0, 0, width, height, 4, 0, 'FLOAT').to_list())
             result[:, :, 3] = 1
         offscreen.free()
         e.set()
     bpy.app.timers.register(_execute, first_interval=0)
     e.wait()
-    print(result)
     return result
 
 def draw_annotation(vertices, indices, color):

--- a/engine/annotations/ade20k.py
+++ b/engine/annotations/ade20k.py
@@ -95,6 +95,5 @@ def draw_annotation(vertices, indices, color):
         {"pos": vertices},
         indices=indices,
     )
-    print(color)
     shader.uniform_float("color", color)
     batch.draw(shader)

--- a/engine/annotations/ade20k.py
+++ b/engine/annotations/ade20k.py
@@ -39,7 +39,7 @@ def render_ade20k_map(context, collection=None, invert=True):
 
         with offscreen.bind():
             fb = gpu.state.active_framebuffer_get()
-            fb.clear(color=(0.0, 0.0, 0.0, 0.0))
+            fb.clear(color=(0.0, 0.0, 0.0, 0.0), depth=1)
             
             gpu.state.depth_test_set('LESS_EQUAL')
             gpu.state.depth_mask_set(True)

--- a/engine/annotations/ade20k.py
+++ b/engine/annotations/ade20k.py
@@ -95,5 +95,6 @@ def draw_annotation(vertices, indices, color):
         {"pos": vertices},
         indices=indices,
     )
+    shader.bind()
     shader.uniform_float("color", color)
     batch.draw(shader)

--- a/engine/annotations/ade20k.py
+++ b/engine/annotations/ade20k.py
@@ -1,0 +1,88 @@
+import bpy
+import gpu
+from gpu_extras.batch import batch_for_shader
+import numpy as np
+import threading
+
+annotation_enum_cases = [('91', 'airplane', 'airplane;aeroplane;plane'), ('127', 'animal', 'animal;animate;being;beast;brute;creature;fauna'), ('93', 'apparel', 'apparel;wearing;apparel;dress;clothes'), ('79', 'arcade machine', 'arcade;machine'), ('31', 'armchair', 'armchair'), ('139', 'ashcan', 'ashcan;trash;can;garbage;can;wastebin;ash;bin;ash-bin;ashbin;dustbin;trash;barrel;trash;bin'), ('87', 'awning', 'awning;sunshade;sunblind'), ('116', 'bag', 'bag'), ('120', 'ball', 'ball'), ('96', 'bannister', 'bannister;banister;balustrade;balusters;handrail'), ('78', 'bar', 'bar'), ('112', 'barrel', 'barrel;cask'), ('41', 'base', 'base;pedestal;stand'), ('113', 'basket', 'basket;handbasket'), ('38', 'bathtub', 'bathtub;bathing;tub;bath;tub'), ('8', 'bed', 'bed'), ('70', 'bench', 'bench'), ('128', 'bicycle', 'bicycle;bike;wheel;cycle'), ('132', 'blanket', 'blanket;cover'), ('64', 'blind', 'blind;screen'), ('77', 'boat', 'boat'), ('63', 'book', 'bookcase'), ('63', 'bookcase', 'bookcase'), ('89', 'booth', 'booth;cubicle;stall;kiosk'), ('99', 'bottle', 'bottle'), ('42', 'box', 'box'), ('62', 'bridge', 'bridge;span'), ('100', 'buffet', 'buffet;counter;sideboard'), ('2', 'building', 'building;edifice'), ('145', 'bulletin board', 'bulletin;board;notice;board'), ('81', 'bus', 'bus;autobus;coach;charabanc;double-decker;jitney;motorbus;motorcoach;omnibus;passenger;vehicle'), ('11', 'cabinet', 'cabinet'), ('107', 'canopy', 'canopy'), ('21', 'car', 'car;auto;automobile;machine;motorcar'), ('56', 'case', 'case;display;case;showcase;vitrine'), ('6', 'ceiling', 'ceiling'), ('20', 'chair', 'chair'), ('86', 'chandelier', 'chandelier;pendant;pendent'), ('45', 'chest of drawers', 'chest;of;drawers;chest;bureau;dresser'), ('149', 'clock', 'clock'), ('65', 'coffee table', 'coffee;table;cocktail;table'), ('43', 'column', 'column;pillar'), ('75', 'computer', 'computer;computing;machine;computing;device;data;processor;electronic;computer;information;processing;system'), ('106', 'conveyer belt', 'conveyer;belt;conveyor;belt;conveyer;conveyor;transporter'), ('46', 'counter', 'counter'), ('71', 'countertop', 'countertop'), ('118', 'cradle', 'cradle'), ('142', 'crt screen', 'crt;screen'), ('19', 'curtain', 'curtain;drape;drapery;mantle;pall'), ('40', 'cushion', 'cushion'), ('34', 'desk', 'desk'), ('92', 'dirt track', 'dirt;track'), ('130', 'dishwasher', 'dishwasher;dish;washer;dishwashing;machine'), ('15', 'door', 'door;double;door'), ('14', 'earth', 'earth;ground'), ('97', 'escalator', 'escalator;moving;staircase;moving;stairway'), ('140', 'fan', 'fan'), ('33', 'fence', 'fence;fencing'), ('30', 'field', 'field'), ('50', 'fireplace', 'fireplace;hearth;open;fireplace'), ('150', 'flag', 'flag'), ('4', 'floor', 'floor;flooring'), ('67', 'flower', 'flower'), ('121', 'food', 'food;solid;food'), ('105', 'fountain', 'fountain'), ('148', 'glass', 'glass;drinking;glass'), ('52', 'grandstand', 'grandstand;covered;stand'), ('10', 'grass', 'grass'), ('69', 'hill', 'hill'), ('134', 'hood', 'hood;exhaust;hood'), ('26', 'house', 'house'), ('80', 'hovel', 'hovel;hut;hutch;shack;shanty'), ('74', 'land', 'kitchen;island'), ('74', 'kitchen island', 'kitchen;island'), ('129', 'lake', 'lake'), ('37', 'lamp', 'lamp'), ('83', 'light', 'light;light;source'), ('125', 'microwave', 'microwave;microwave;oven'), ('117', 'minibike', 'minibike;motorbike'), ('28', 'mirror', 'mirror'), ('144', 'monitor', 'monitor;monitoring;device'), ('17', 'mountain', 'mountain;mount'), ('98', 'ottoman', 'ottoman;pouf;pouffe;puff;hassock'), ('119', 'oven', 'oven'), ('23', 'painting', 'painting;picture'), ('73', 'palm', 'palm;palm;tree'), ('53', 'path', 'path'), ('13', 'person', 'person;individual;someone;somebody;mortal;soul'), ('141', 'pier', 'pier;wharf;wharfage;dock'), ('58', 'pillow', 'pillow'), ('18', 'plant', 'plant;flora;plant;life'), ('143', 'plate', 'plate'), ('109', 'plaything', 'plaything;toy'), ('94', 'pole', 'pole'), ('57', 'pool table', 'pool;table;billiard;table;snooker;table'), ('101', 'poster', 'poster;posting;placard;notice;bill;card'), ('147', 'radiator', 'radiator'), ('39', 'railing', 'railing;rail'), ('51', 'refrigerator', 'refrigerator;icebox'), ('61', 'river', 'river'), ('7', 'road', 'road;route'), ('35', 'rock', 'rock;stone'), ('29', 'rug', 'rug;carpet;carpeting'), ('55', 'runway', 'runway'), ('47', 'sand', 'sand'), ('135', 'sconce', 'sconce'), ('59', 'screen door', 'screen;door;screen'), ('59', 'screen', 'screen;door;screen'), ('133', 'sculpture', 'sculpture'), ('27', 'sea', 'sea'), ('32', 'seat', 'seat'), ('25', 'shelf', 'shelf'), ('104', 'ship', 'ship'), ('146', 'shower', 'shower'), ('12', 'sidewalk', 'sidewalk;pavement'), ('44', 'signboard', 'signboard;sign'), ('48', 'sink', 'sink'), ('3', 'sky', 'sky'), ('49', 'skyscraper', 'skyscraper'), ('24', 'sofa', 'sofa;couch;lounge'), ('102', 'stage', 'stage'), ('54', 'step', 'stairs;steps'), ('54', 'stairs', 'stairs;steps'), ('60', 'stairway', 'stairway;staircase'), ('72', 'stove', 'stove;kitchen;stove;range;kitchen;range;cooking;stove'), ('88', 'streetlight', 'streetlight;street;lamp'), ('110', 'swimming pool', 'swimming;pool;swimming;bath;natatorium'), ('76', 'swivel chair', 'swivel;chair'), ('16', 'table', 'table'), ('123', 'tank', 'tank;storage;tank'), ('90', 'television receiver', 'television;television;receiver;television;set;tv;tv;set;idiot;box;boob;tube;telly;goggle;box'), ('115', 'tent', 'tent;collapsible;shelter'), ('66', 'stool', 'toilet;can;commode;crapper;pot;potty;stool;throne'), ('66', 'pot', 'toilet;can;commode;crapper;pot;potty;stool;throne'), ('66', 'toilet', 'toilet;can;commode;crapper;pot;potty;stool;throne'), ('82', 'towel', 'towel'), ('85', 'tower', 'tower'), ('124', 'trade name', 'trade;name;brand;name;brand;marque'), ('137', 'traffic light', 'traffic;light;traffic;signal;stoplight'), ('138', 'tray', 'tray'), ('5', 'tree', 'tree'), ('84', 'truck', 'truck;motortruck'), ('103', 'van', 'van'), ('136', 'vase', 'vase'), ('1', 'wall', 'wall'), ('36', 'wardrobe', 'wardrobe;closet;press'), ('108', 'washer', 'washer;automatic;washer;washing;machine'), ('22', 'water', 'water'), ('114', 'waterfall', 'waterfall;falls'), ('9', 'windowpane', 'windowpane;window')]
+annotation_colors = {'80': (1.0, 0.0, 0.996078431372549, 1.0), '140': (0.00392156862745098, 0.9607843137254902, 1.0, 1.0), '115': (0.43529411764705883, 0.8784313725490196, 0.996078431372549, 1.0), '33': (1.0, 0.7215686274509804, 0.023529411764705882, 1.0), '77': (0.6784313725490196, 1.0, 0.0, 1.0), '58': (0.0, 0.9215686274509803, 1.0, 1.0), '98': (0.996078431372549, 0.6, 0.0, 1.0), '74': (0.0, 1.0, 0.1607843137254902, 1.0), '150': (0.3568627450980392, 0.0, 0.996078431372549, 1.0), '117': (0.6431372549019608, 0.0, 1.0, 1.0), '18': (0.8, 1.0, 0.01568627450980392, 1.0), '145': (0.7215686274509804, 1.0, 0.0, 1.0), '63': (0.0, 1.0, 0.9607843137254902, 1.0), '9': (0.9019607843137255, 0.9019607843137255, 0.9019607843137255, 1.0), '34': (0.0392156862745098, 1.0, 0.2784313725490196, 1.0), '120': (1.0, 0.00392156862745098, 0.6352941176470588, 1.0), '61': (0.0392156862745098, 0.7843137254901961, 0.7843137254901961, 1.0), '32': (0.027450980392156862, 0.996078431372549, 0.8745098039215686, 1.0), '124': (0.5215686274509804, 0.996078431372549, 0.0, 1.0), '6': (0.4666666666666667, 0.47058823529411764, 0.3137254901960784, 1.0), '104': (1.0, 0.9215686274509803, 0.0, 1.0), '38': (0.4, 0.03137254901960784, 1.0, 1.0), '106': (0.5215686274509804, 0.0, 1.0, 1.0), '56': (0.00392156862745098, 0.0, 0.996078431372549, 1.0), '12': (0.9215686274509803, 1.0, 0.027450980392156862, 1.0), '19': (1.0, 0.2, 0.03137254901960784, 1.0), '70': (0.7607843137254902, 1.0, 0.00392156862745098, 1.0), '88': (0.00392156862745098, 0.2784313725490196, 1.0, 1.0), '62': (1.0, 0.3254901960784314, 0.00392156862745098, 1.0), '7': (0.5490196078431373, 0.5490196078431373, 0.5490196078431373, 1.0), '29': (1.0, 0.03529411764705882, 0.3607843137254902, 1.0), '82': (1.0, 0.0, 0.4, 1.0), '142': (0.47843137254901963, 0.00392156862745098, 1.0, 1.0), '11': (0.8784313725490196, 0.0196078431372549, 1.0, 1.0), '147': (1.0, 0.8392156862745098, 0.00784313725490196, 1.0), '76': (0.0392156862745098, 0.0, 1.0, 1.0), '146': (0.0, 0.5215686274509804, 0.996078431372549, 1.0), '54': (1.0, 0.8784313725490196, 0.00392156862745098, 1.0), '94': (0.2, 0.0, 1.0, 1.0), '59': (0.0, 0.8, 1.0, 1.0), '118': (0.6039215686274509, 0.0, 1.0, 1.0), '39': (1.0, 0.24313725490196078, 0.027450980392156862, 1.0), '101': (0.5607843137254902, 0.996078431372549, 0.00392156862745098, 1.0), '46': (0.9254901960784314, 0.043137254901960784, 1.0, 1.0), '110': (0.0, 0.7215686274509804, 1.0, 1.0), '45': (0.023529411764705882, 0.2, 1.0, 1.0), '93': (0.0, 0.44313725490196076, 0.996078431372549, 1.0), '13': (0.5882352941176471, 0.0196078431372549, 0.24313725490196078, 1.0), '50': (0.9803921568627451, 0.03529411764705882, 0.058823529411764705, 1.0), '64': (0.00392156862745098, 0.23921568627450981, 1.0, 1.0), '30': (0.43529411764705883, 0.03529411764705882, 1.0, 1.0), '99': (0.0, 1.0, 0.043137254901960784, 1.0), '35': (1.0, 0.1568627450980392, 0.03529411764705882, 1.0), '125': (0.996078431372549, 0.0, 0.9176470588235294, 1.0), '105': (0.03137254901960784, 0.7215686274509804, 0.6705882352941176, 1.0), '135': (0.0, 0.1607843137254902, 1.0, 1.0), '53': (1.0, 0.11764705882352941, 0.0, 1.0), '66': (0.0, 1.0, 0.5215686274509804, 1.0), '8': (0.8, 0.0196078431372549, 0.996078431372549, 1.0), '26': (1.0, 0.03137254901960784, 0.8666666666666667, 1.0), '14': (0.47058823529411764, 0.47058823529411764, 0.27450980392156865, 1.0), '73': (0.0, 0.3215686274509804, 0.996078431372549, 1.0), '23': (1.0, 0.023529411764705882, 0.2, 1.0), '24': (0.043137254901960784, 0.4, 1.0, 1.0), '97': (0.0, 1.0, 0.6392156862745098, 1.0), '132': (0.0784313725490196, 0.0, 1.0, 1.0), '100': (1.0, 0.4392156862745098, 0.0, 1.0), '83': (1.0, 0.6784313725490196, 0.00392156862745098, 1.0), '85': (0.996078431372549, 0.7215686274509804, 0.7215686274509804, 1.0), '79': (1.0, 0.3607843137254902, 0.0, 1.0), '144': (0.0, 0.3607843137254902, 1.0, 1.0), '113': (0.3568627450980392, 1.0, 0.0, 1.0), '133': (1.0, 1.0, 0.0, 1.0), '52': (0.12156862745098039, 1.0, 0.0, 1.0), '28': (0.8627450980392157, 0.8627450980392157, 0.8627450980392157, 1.0), '10': (0.0196078431372549, 0.9803921568627451, 0.027450980392156862, 1.0), '2': (0.7058823529411765, 0.47058823529411764, 0.47058823529411764, 1.0), '103': (0.6392156862745098, 0.996078431372549, 0.0, 1.0), '91': (0.00392156862745098, 0.996078431372549, 0.3254901960784314, 1.0), '121': (1.0, 0.8, 0.0, 1.0), '86': (0.0, 0.12156862745098039, 0.996078431372549, 1.0), '27': (0.03529411764705882, 0.027450980392156862, 0.9058823529411765, 1.0), '114': (0.0, 0.8823529411764706, 1.0, 1.0), '20': (0.796078431372549, 0.27450980392156865, 0.011764705882352941, 1.0), '134': (0.0, 0.6, 1.0, 1.0), '17': (0.5568627450980392, 1.0, 0.5450980392156862, 1.0), '3': (0.023529411764705882, 0.9019607843137255, 0.9019607843137255, 1.0), '65': (0.00392156862745098, 0.996078431372549, 0.4392156862745098, 1.0), '139': (0.6823529411764706, 0.0, 1.0, 1.0), '130': (0.8392156862745098, 1.0, 0.0, 1.0), '136': (0.00392156862745098, 1.0, 0.803921568627451, 1.0), '51': (0.0784313725490196, 1.0, 0.0, 1.0), '15': (0.03137254901960784, 1.0, 0.20392156862745098, 1.0), '55': (0.6, 1.0, 0.0, 1.0), '5': (0.01568627450980392, 0.7843137254901961, 0.023529411764705882, 1.0), '22': (0.23921568627450981, 0.9019607843137255, 0.984313725490196, 1.0), '72': (0.2, 1.0, 0.0, 1.0), '41': (1.0, 0.4823529411764706, 0.0392156862745098, 1.0), '137': (0.1607843137254902, 0.0, 1.0, 1.0), '92': (0.0, 0.0392156862745098, 1.0, 1.0), '21': (0.0, 0.4, 0.7843137254901961, 1.0), '109': (1.0, 0.0, 0.11764705882352941, 1.0), '1': (0.47058823529411764, 0.47058823529411764, 0.47058823529411764, 1.0), '67': (1.0, 0.00392156862745098, 0.011764705882352941, 1.0), '60': (0.12156862745098039, 0.0, 0.996078431372549, 1.0), '44': (1.0, 0.0196078431372549, 0.6039215686274509, 1.0), '69': (1.0, 0.4, 0.0, 1.0), '107': (0.0, 0.996078431372549, 0.36470588235294116, 1.0), '4': (0.3137254901960784, 0.19607843137254902, 0.20392156862745098, 1.0), '90': (0.0, 1.0, 0.7647058823529411, 1.0), '149': (0.396078431372549, 1.0, 0.0, 1.0), '129': (0.0392156862745098, 0.7490196078431373, 0.8313725490196079, 1.0), '75': (0.0, 1.0, 0.6784313725490196, 1.0), '141': (0.2823529411764706, 0.0, 1.0, 1.0), '128': (1.0, 0.9607843137254902, 0.0, 1.0), '57': (1.0, 0.2784313725490196, 0.0, 1.0), '49': (0.5490196078431373, 0.5490196078431373, 0.5490196078431373, 1.0), '108': (0.7215686274509804, 0.0, 0.996078431372549, 1.0), '87': (0.0, 1.0, 0.23921568627450981, 1.0), '43': (1.0, 0.03137254901960784, 0.16470588235294117, 1.0), '71': (0.0, 0.5607843137254902, 1.0, 1.0), '31': (0.03529411764705882, 0.996078431372549, 0.8352941176470589, 1.0), '81': (1.0, 0.0, 0.9568627450980393, 1.0), '36': (0.027450980392156862, 1.0, 1.0, 1.0), '143': (0.0, 1.0, 0.7254901960784313, 1.0), '148': (0.09411764705882353, 0.7607843137254902, 0.7607843137254902, 1.0), '102': (0.3215686274509804, 0.0, 1.0, 1.0), '84': (1.0, 0.0, 0.08235294117647059, 1.0), '47': (0.6274509803921569, 0.5882352941176471, 0.07450980392156863, 1.0), '127': (1.0, 0.0, 0.47843137254901963, 1.0), '16': (0.996078431372549, 0.023529411764705882, 0.3215686274509804, 1.0), '78': (0.0, 0.996078431372549, 0.6078431372549019, 1.0), '25': (1.0, 0.023529411764705882, 0.27450980392156865, 1.0), '138': (0.16862745098039217, 0.996078431372549, 0.011764705882352941, 1.0), '42': (0.00392156862745098, 1.0, 0.07450980392156863, 1.0), '119': (0.2784313725490196, 1.0, 0.00392156862745098, 1.0), '112': (0.996078431372549, 0.0, 0.4392156862745098, 1.0), '89': (0.996078431372549, 0.0, 0.796078431372549, 1.0), '96': (0.0, 0.47843137254901963, 1.0, 1.0), '37': (0.8823529411764706, 1.0, 0.03529411764705882, 1.0), '48': (0.0, 0.6392156862745098, 0.996078431372549, 1.0), '116': (0.27058823529411763, 0.7176470588235294, 0.6196078431372549, 1.0), '40': (1.0, 0.7607843137254902, 0.027450980392156862, 1.0), '123': (0.0, 1.0, 0.9176470588235294, 1.0)}
+
+def annotation_update(self, context):
+    self.color = annotation_colors[self.annotation][:3]
+
+class ObjectADE20KData(bpy.types.PropertyGroup):
+    bl_label = "ADE20K Segmentation"
+    bl_idname = "dream_textures.ObjectADE20KData"
+
+    enabled: bpy.props.BoolProperty(name="Enabled", default=False)
+    annotation: bpy.props.EnumProperty(
+        name="Class",
+        items=annotation_enum_cases,
+        update=annotation_update
+    )
+    # for visualization only
+    color: bpy.props.FloatVectorProperty(name="", subtype='COLOR', default=annotation_colors[annotation_enum_cases[0][0]][:3])
+
+def render_ade20k_map(context, collection=None, invert=True):
+    e = threading.Event()
+    result = None
+    def _execute():
+        nonlocal result
+        width, height = context.scene.render.resolution_x, context.scene.render.resolution_y
+        matrix = context.scene.camera.matrix_world.inverted()
+        projection_matrix = context.scene.camera.calc_matrix_camera(
+            context,
+            x=width,
+            y=height
+        )
+        offscreen = gpu.types.GPUOffScreen(width, height)
+
+        with offscreen.bind():
+            fb = gpu.state.active_framebuffer_get()
+            fb.clear(color=(0.0, 0.0, 0.0, 0.0))
+            
+            gpu.state.depth_test_set('LESS_EQUAL')
+            gpu.state.depth_mask_set(True)
+            with gpu.matrix.push_pop():
+                gpu.matrix.load_matrix(matrix)
+                gpu.matrix.load_projection_matrix(projection_matrix)
+
+                for object in (context.scene.objects if collection is None else collection.objects):
+                    object = object.evaluated_get(context)
+                    if not hasattr(object, 'dream_textures_ade20k') or not object.dream_textures_ade20k.enabled:
+                        continue
+                    try:
+                        mesh = object.to_mesh(depsgraph=context).copy()
+                    except:
+                        continue
+                    if mesh is None:
+                        continue
+                    vertices = np.empty((len(mesh.vertices), 3), 'f')
+                    indices = np.empty((len(mesh.loop_triangles), 3), 'i')
+
+                    mesh.transform(object.matrix_world)
+                    mesh.vertices.foreach_get("co", np.reshape(vertices, len(mesh.vertices) * 3))
+                    mesh.loop_triangles.foreach_get("vertices", np.reshape(indices, len(mesh.loop_triangles) * 3))
+                    
+                    color = annotation_colors[object.dream_textures_ade20k.annotation]
+
+                    draw_annotation(vertices, indices, (color[0], color[1], color[2], 1))
+            result = np.array(fb.read_color(0, 0, width, height, 4, 0, 'FLOAT').to_list())
+            result[:, :, 3] = 1
+        offscreen.free()
+        e.set()
+    bpy.app.timers.register(_execute, first_interval=0)
+    e.wait()
+    print(result)
+    return result
+
+def draw_annotation(vertices, indices, color):
+    shader = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
+    batch = batch_for_shader(
+        shader, 'TRIS',
+        {"pos": vertices},
+        indices=indices,
+    )
+    print(color)
+    shader.uniform_float("color", color)
+    batch.draw(shader)

--- a/engine/annotations/depth.py
+++ b/engine/annotations/depth.py
@@ -46,14 +46,24 @@ def render_depth_map(context, collection=None, invert=True, width=None, height=N
                         indices=indices,
                     )
                     batch.draw(shader)
-                for object in (context.object_instances if collection is None else collection.objects):
-                    try:
-                        mesh = object.object.to_mesh()
-                        if mesh is not None:
-                            render_mesh(mesh, object.matrix_world)
-                            object.object.to_mesh_clear()
-                    except:
-                        continue
+                if collection is None:
+                    for object in context.object_instances:
+                        try:
+                            mesh = object.object.to_mesh()
+                            if mesh is not None:
+                                render_mesh(mesh, object.matrix_world)
+                                object.object.to_mesh_clear()
+                        except:
+                            continue
+                else:
+                    for object in collection.objects:
+                        try:
+                            mesh = object.to_mesh(depsgraph=context)
+                            if mesh is not None:
+                                render_mesh(mesh, object.matrix_world)
+                                object.to_mesh_clear()
+                        except:
+                            continue
             depth = np.array(fb.read_depth(0, 0, width, height).to_list())
             if invert:
                 depth = 1 - depth

--- a/engine/annotations/openpose.py
+++ b/engine/annotations/openpose.py
@@ -52,33 +52,33 @@ class Bone(enum.IntEnum):
     def name_detection_options(self):
         match self:
             case Bone.NOSE:
-                return [('nose_master', Side.TAIL), ('nose.001', Side.TAIL)]
+                return [('nose_master', Side.TAIL), ('nose.001', Side.TAIL), ('Head', Side.TAIL)]
             case Bone.CHEST:
-                return [('spine_fk.003', Side.TAIL), ('spine.003', Side.TAIL)]
+                return [('spine_fk.003', Side.TAIL), ('spine.003', Side.TAIL), ('Spine4', Side.TAIL)]
             case Bone.SHOULDER_L:
-                return [('shoulder_ik.L', Side.TAIL), ('shoulder.L', Side.TAIL)]
+                return [('shoulder_ik.L', Side.TAIL), ('shoulder.L', Side.TAIL), ('LeftShoulder', Side.TAIL)]
             case Bone.SHOULDER_R:
-                return [('shoulder_ik.R', Side.TAIL), ('shoulder.R', Side.TAIL)]
+                return [('shoulder_ik.R', Side.TAIL), ('shoulder.R', Side.TAIL), ('RightShoulder', Side.TAIL)]
             case Bone.ELBOW_L:
-                return [('upper_arm_ik.L', Side.TAIL), ('upper_arm.L', Side.TAIL)]
+                return [('upper_arm_ik.L', Side.TAIL), ('upper_arm.L', Side.TAIL), ('LeftArm', Side.TAIL)]
             case Bone.ELBOW_R:
-                return [('upper_arm_ik.R', Side.TAIL), ('upper_arm.R', Side.TAIL)]
+                return [('upper_arm_ik.R', Side.TAIL), ('upper_arm.R', Side.TAIL), ('RightArm', Side.TAIL)]
             case Bone.HAND_L:
-                return [('hand_ik.L', Side.TAIL), ('forearm.L', Side.TAIL)]
+                return [('hand_ik.L', Side.TAIL), ('forearm.L', Side.TAIL), ('LeftForeArm', Side.TAIL)]
             case Bone.HAND_R:
-                return [('hand_ik.R', Side.TAIL), ('forearm.R', Side.TAIL)]
+                return [('hand_ik.R', Side.TAIL), ('forearm.R', Side.TAIL), ('RightForeArm', Side.TAIL)]
             case Bone.HIP_L:
-                return [('thigh_ik.L', Side.HEAD), ('thigh.L', Side.HEAD)]
+                return [('thigh_ik.L', Side.HEAD), ('thigh.L', Side.HEAD), ('LeftThigh', Side.HEAD)]
             case Bone.HIP_R:
-                return [('thigh_ik.R', Side.HEAD), ('thigh.R', Side.HEAD)]
+                return [('thigh_ik.R', Side.HEAD), ('thigh.R', Side.HEAD), ('RightThigh', Side.HEAD)]
             case Bone.KNEE_L:
-                return [('thigh_ik.L', Side.TAIL), ('thigh.L', Side.TAIL)]
+                return [('thigh_ik.L', Side.TAIL), ('thigh.L', Side.TAIL), ('LeftShin', Side.HEAD)]
             case Bone.KNEE_R:
-                return [('thigh_ik.R', Side.TAIL), ('thigh.R', Side.TAIL)]
+                return [('thigh_ik.R', Side.TAIL), ('thigh.R', Side.TAIL), ('RightShin', Side.HEAD)]
             case Bone.FOOT_L:
-                return [('foot_ik.L', Side.TAIL), ('shin.L', Side.TAIL)]
+                return [('foot_ik.L', Side.TAIL), ('shin.L', Side.TAIL), ('LeftFoot', Side.HEAD)]
             case Bone.FOOT_R:
-                return [('foot_ik.R', Side.TAIL), ('shin.R', Side.TAIL)]
+                return [('foot_ik.R', Side.TAIL), ('shin.R', Side.TAIL), ('RightFoot', Side.HEAD)]
             case Bone.EYE_L:
                 return [('master_eye.L', Side.TAIL), ('eye.L', Side.TAIL)]
             case Bone.EYE_R:

--- a/engine/annotations/openpose.py
+++ b/engine/annotations/openpose.py
@@ -185,10 +185,7 @@ def render_openpose_map(context, collection=None):
 
                 shader = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
                 batch = batch_for_shader(shader, 'TRI_STRIP', {"pos": [(-ratio, -1, 0), (-ratio, 1, 0), (ratio, -1, 0), (ratio, 1, 0)]})
-                shader.uniform_float("color", (0, 0, 0, 1))
-                batch.draw(shader)
-
-                batch = batch_for_shader(shader, 'TRI_STRIP', {"pos": [(-ratio, -1, 0), (-ratio, 1, 0), (ratio, -1, 0), (ratio, 1, 0)]})
+                shader.bind()
                 shader.uniform_float("color", (0, 0, 0, 1))
                 batch.draw(shader)
 

--- a/engine/annotations/openpose.py
+++ b/engine/annotations/openpose.py
@@ -109,6 +109,8 @@ class Bone(enum.IntEnum):
             case Bone.EAR_L: return (255, 0, 85)
             case Bone.EAR_R: return (255, 0, 170)
 
+openpose_bones = ((str(b.value), b.name.title(), '') for b in Bone)
+openpose_sides = ((str(s.value), s.name.title(), '') for s in Side)
 class BoneOpenPoseData(bpy.types.PropertyGroup):
     bl_label = "OpenPose"
     bl_idname = "dream_textures.BoneOpenPoseData"
@@ -116,11 +118,11 @@ class BoneOpenPoseData(bpy.types.PropertyGroup):
     enabled: bpy.props.BoolProperty(name="Enabled", default=False)
     bone: bpy.props.EnumProperty(
         name="OpenPose Bone",
-        items=((str(b.value), b.name.title(), '') for b in Bone)
+        items=openpose_bones
     )
     side: bpy.props.EnumProperty(
         name="Bone Side",
-        items=((str(s.value), s.name.title(), '') for s in Side)
+        items=openpose_sides
     )
 
 ArmatureOpenPoseData = type('ArmatureOpenPoseData', (bpy.types.PropertyGroup,), {

--- a/engine/annotations/viewport.py
+++ b/engine/annotations/viewport.py
@@ -1,0 +1,51 @@
+import bpy
+import gpu
+import numpy as np
+import threading
+
+def render_viewport_color(context, width=None, height=None, matrix=None, projection_matrix=None, main_thread=False):
+    e = threading.Event()
+    result = None
+
+    width, height = width or context.scene.render.resolution_x, height or context.scene.render.resolution_y
+    matrix = matrix or context.scene.camera.matrix_world.inverted()
+    projection_matrix = projection_matrix or context.scene.camera.calc_matrix_camera(
+        context,
+        x=width,
+        y=height
+    )
+
+    def _execute():
+        nonlocal result
+        offscreen = gpu.types.GPUOffScreen(width, height)
+
+        with offscreen.bind():
+            fb = gpu.state.active_framebuffer_get()
+            fb.clear(color=(0.0, 0.0, 0.0, 0.0), depth=1)
+            gpu.state.depth_test_set('LESS_EQUAL')
+            gpu.state.depth_mask_set(True)
+            with gpu.matrix.push_pop():
+                gpu.matrix.load_matrix(matrix)
+                gpu.matrix.load_projection_matrix(projection_matrix)
+                area = next(a for a in bpy.context.screen.areas if a.type == 'VIEW_3D')
+                offscreen.draw_view3d(
+                    context.scene,
+                    context.view_layer,
+                    next(s for s in area.spaces),
+                    next(r for r in area.regions if r.type == 'WINDOW'),
+                    matrix,
+                    projection_matrix,
+                    do_color_management=False
+                )
+            color = np.array(fb.read_color(0, 0, width, height, 4, 0, 'FLOAT').to_list())
+        gpu.state.depth_test_set('NONE')
+        offscreen.free()
+        result = color
+        e.set()
+    if main_thread:
+        _execute()
+        return result
+    else:
+        bpy.app.timers.register(_execute, first_interval=0)
+        e.wait()
+        return result

--- a/engine/engine.py
+++ b/engine/engine.py
@@ -117,6 +117,8 @@ def engine_panels():
             col = layout.column(align=True)
             col.prop(context.scene.render, "resolution_x")
             col.prop(context.scene.render, "resolution_y", text="Y")
+            
+            layout.prop(context.scene.render, "resolution_percentage")
     yield FormatPanel
 
     class NodeTreeInputsPanel(RenderPanel):

--- a/engine/engine.py
+++ b/engine/engine.py
@@ -102,8 +102,9 @@ class DreamTexturesRenderEngineProperties(bpy.types.PropertyGroup):
 def engine_panels():
     bpy.types.RENDER_PT_output.COMPAT_ENGINES.add(DreamTexturesRenderEngine.bl_idname)
     bpy.types.RENDER_PT_color_management.COMPAT_ENGINES.add(DreamTexturesRenderEngine.bl_idname)
-    bpy.types.DATA_PT_lens.COMPAT_ENGINES.add(DreamTexturesRenderEngine.bl_idname)
     bpy.types.RENDER_PT_stamp.COMPAT_ENGINES.add(DreamTexturesRenderEngine.bl_idname)
+    bpy.types.RENDER_PT_format.COMPAT_ENGINES.add(DreamTexturesRenderEngine.bl_idname)
+    bpy.types.DATA_PT_lens.COMPAT_ENGINES.add(DreamTexturesRenderEngine.bl_idname)
     def get_prompt(context):
         return context.scene.dream_textures_engine_prompt
     class RenderPanel(bpy.types.Panel, RenderButtonsPanel):
@@ -125,24 +126,6 @@ def engine_panels():
 
     # Render Properties
     yield from optimization_panels(RenderPanel, 'engine', get_prompt, "")
-
-    # Output Properties
-    class FormatPanel(OutputPanel):
-        """Create a subpanel for format options"""
-        bl_idname = f"DREAM_PT_dream_panel_format_engine"
-        bl_label = "Format"
-
-        def draw(self, context):
-            super().draw(context)
-            layout = self.layout
-            layout.use_property_split = True
-
-            col = layout.column(align=True)
-            col.prop(context.scene.render, "resolution_x")
-            col.prop(context.scene.render, "resolution_y", text="Y")
-            
-            layout.prop(context.scene.render, "resolution_percentage")
-    yield FormatPanel
 
     class NodeTreeInputsPanel(RenderPanel):
         """Create a subpanel for format options"""

--- a/engine/engine.py
+++ b/engine/engine.py
@@ -214,3 +214,34 @@ def engine_panels():
             layout.prop(bone.dream_textures_openpose, "side")
 
     yield OpenPoseBonePanel
+
+    class ADE20KObjectPanel(bpy.types.Panel):
+        bl_idname = "DREAM_PT_dream_textures_object_ade20k"
+        bl_label = "ADE20K Segmentation"
+        bl_space_type = 'PROPERTIES'
+        bl_region_type = 'WINDOW'
+        bl_context = "object"
+
+        @classmethod
+        def poll(cls, context):
+            return context.object and context.scene.render.engine == 'DREAM_TEXTURES'
+        
+        def draw_header(self, context):
+            object = context.object
+            if object:
+                self.layout.prop(object.dream_textures_ade20k, "enabled", text="")
+
+        def draw(self, context):
+            layout = self.layout
+            layout.use_property_split = True
+
+            object = context.object
+
+            layout.enabled = object.dream_textures_ade20k.enabled
+            r = layout.split(factor=0.9)
+            r.prop(object.dream_textures_ade20k, "annotation")
+            c = r.column()
+            c.enabled = False
+            c.prop(object.dream_textures_ade20k, "color")
+
+    yield ADE20KObjectPanel

--- a/engine/node_executor.py
+++ b/engine/node_executor.py
@@ -17,7 +17,10 @@ def execute_node(node, context, cache):
                 for input in context.depsgraph.scene.dream_textures_render_engine.node_tree.inputs
             }
         case 'GROUP_OUTPUT':
-            return cache[node.inputs[0].links[0].from_socket.node]
+            return [
+                (input.name, cache[input.links[0].from_socket.node][input.links[0].from_socket.name])
+                for input in node.inputs if len(input.links) > 0
+            ]
         case _:
             if node in cache:
                 return cache[node]
@@ -51,4 +54,4 @@ def execute(node_tree, depsgraph, node_begin=lambda node: None, node_update=lamb
         result = execute_node(node, NodeExecutionContext(depsgraph, node_update, test_break), cache)
         cache[node] = result
         node_end(node)
-    return next(iter(cache[output].values()))
+    return cache[output]

--- a/engine/nodes/annotation_nodes.py
+++ b/engine/nodes/annotation_nodes.py
@@ -38,16 +38,18 @@ class NodeAnnotationOpenPose(DreamTexturesNode):
     bl_idname = "dream_textures.node_annotation_openpose"
     bl_label = "OpenPose Map"
 
+    src: bpy.props.EnumProperty(name="", items=annotation_src, update=_update_annotation_inputs)
+
     def init(self, context):
         self.inputs.new("NodeSocketCollection", "Collection")
 
         self.outputs.new("NodeSocketColor", "OpenPose Map")
 
     def draw_buttons(self, context, layout):
-        pass
+        layout.prop(self, "src")
 
     def execute(self, context, collection):
-        openpose_map = openpose.render_openpose_map(context.depsgraph, collection=collection)
+        openpose_map = openpose.render_openpose_map(context.depsgraph, collection=collection if self.src == 'collection' else None)
         context.update(openpose_map)
         return {
             'OpenPose Map': openpose_map
@@ -57,16 +59,18 @@ class NodeAnnotationADE20K(DreamTexturesNode):
     bl_idname = "dream_textures.node_annotation_ade20k"
     bl_label = "ADE20K Segmentation Map"
 
+    src: bpy.props.EnumProperty(name="", items=annotation_src, update=_update_annotation_inputs)
+
     def init(self, context):
         self.inputs.new("NodeSocketCollection", "Collection")
 
         self.outputs.new("NodeSocketColor", "Segmentation Map")
 
     def draw_buttons(self, context, layout):
-        pass
+        layout.prop(self, "src")
 
     def execute(self, context, collection):
-        ade20k_map = ade20k.render_ade20k_map(context.depsgraph, collection=collection)
+        ade20k_map = ade20k.render_ade20k_map(context.depsgraph, collection=collection if self.src == 'collection' else None)
         context.update(ade20k_map)
         return {
             'Segmentation Map': ade20k_map

--- a/engine/nodes/annotation_nodes.py
+++ b/engine/nodes/annotation_nodes.py
@@ -2,6 +2,7 @@ import bpy
 from ..node import DreamTexturesNode
 from ..annotations import depth
 from ..annotations import openpose
+from ..annotations import ade20k
 
 annotation_src = (
     ('collection', 'Collection', 'Render the annotation for a specific collection'),
@@ -50,4 +51,23 @@ class NodeAnnotationOpenPose(DreamTexturesNode):
         context.update(openpose_map)
         return {
             'OpenPose Map': openpose_map
+        }
+
+class NodeAnnotationADE20K(DreamTexturesNode):
+    bl_idname = "dream_textures.node_annotation_ade20k"
+    bl_label = "ADE20K Segmentation Map"
+
+    def init(self, context):
+        self.inputs.new("NodeSocketCollection", "Collection")
+
+        self.outputs.new("NodeSocketColor", "Segmentation Map")
+
+    def draw_buttons(self, context, layout):
+        pass
+
+    def execute(self, context, collection):
+        ade20k_map = ade20k.render_ade20k_map(context.depsgraph, collection=collection)
+        context.update(ade20k_map)
+        return {
+            'Segmentation Map': ade20k_map
         }

--- a/engine/nodes/annotation_nodes.py
+++ b/engine/nodes/annotation_nodes.py
@@ -3,6 +3,7 @@ from ..node import DreamTexturesNode
 from ..annotations import depth
 from ..annotations import openpose
 from ..annotations import ade20k
+from ..annotations import viewport
 
 annotation_src = (
     ('collection', 'Collection', 'Render the annotation for a specific collection'),
@@ -74,4 +75,21 @@ class NodeAnnotationADE20K(DreamTexturesNode):
         context.update(ade20k_map)
         return {
             'Segmentation Map': ade20k_map
+        }
+
+class NodeAnnotationViewport(DreamTexturesNode):
+    bl_idname = "dream_textures.node_annotation_viewport"
+    bl_label = "Viewport Color"
+
+    def init(self, context):
+        self.outputs.new("NodeSocketColor", "Viewport Color")
+
+    def draw_buttons(self, context, layout):
+        pass
+
+    def execute(self, context):
+        color = viewport.render_viewport_color(context.depsgraph)
+        context.update(color)
+        return {
+            'Viewport Color': color
         }

--- a/engine/nodes/pipeline_nodes.py
+++ b/engine/nodes/pipeline_nodes.py
@@ -98,6 +98,7 @@ class NodeStableDiffusion(DreamTexturesNode):
         layout.prop(prompt, "pipeline", text="")
         layout.prop(prompt, "model", text="")
         layout.prop(prompt, "scheduler", text="")
+        layout.prop(prompt, "seamless_axes", text="")
     
     def execute(self, context, prompt, negative_prompt, width, height, steps, seed, cfg_scale, controlnets, depth_map, source_image, noise_strength):
         self.prompt.use_negative_prompt = True

--- a/engine/nodes/pipeline_nodes.py
+++ b/engine/nodes/pipeline_nodes.py
@@ -9,6 +9,7 @@ from ...property_groups.control_net import control_net_options
 from ...property_groups.dream_prompt import DreamPrompt
 from ..annotations import openpose
 from ..annotations import depth
+from ..annotations import ade20k
 import threading
 
 class NodeSocketControlNet(bpy.types.NodeSocket):
@@ -28,6 +29,7 @@ class ControlType(enum.IntEnum):
     DEPTH = 1
     OPENPOSE = 2
     NORMAL = 3
+    ADE20K_SEGMENTATION = 4
 
 @dataclass
 class ControlNet:
@@ -48,6 +50,8 @@ class ControlNet:
                     return np.flipud(openpose.render_openpose_map(context, collection=self.collection))
                 case ControlType.NORMAL:
                     pass
+                case ControlType.ADE20K_SEGMENTATION:
+                    return np.flipud(ade20k.render_ade20k_map(context, collection=self.collection))
 
 def _update_stable_diffusion_sockets(self, context):
     self.inputs['Source Image'].enabled = self.task in {'image_to_image', 'depth_to_image'}
@@ -237,6 +241,7 @@ class NodeControlNet(DreamTexturesNode):
         ('DEPTH', 'Depth', '', 1),
         ('OPENPOSE', 'OpenPose', '', 2),
         ('NORMAL', 'Normal Map', '', 3),
+        ('ADE20K_SEGMENTATION', 'ADE20K Segmentation', '', 4),
     ))
 
     def init(self, context):
@@ -251,7 +256,8 @@ class NodeControlNet(DreamTexturesNode):
     def draw_buttons(self, context, layout):
         layout.prop(self, "control_net")
         layout.prop(self, "input_type")
-        layout.prop(self, "control_type")
+        if self.input_type != 'image':
+            layout.prop(self, "control_type")
     
     def execute(self, context, collection, image, conditioning_scale):
         return {

--- a/engine/nodes/utility_nodes.py
+++ b/engine/nodes/utility_nodes.py
@@ -2,6 +2,7 @@ import bpy
 import numpy as np
 import random
 from ..node import DreamTexturesNode
+from ...property_groups.dream_prompt import seed_clamp
 
 class NodeMath(DreamTexturesNode):
     bl_idname = "dream_textures.node_math"
@@ -77,6 +78,23 @@ class NodeRandomSeed(DreamTexturesNode):
     def execute(self, context):
         return {
             'Value': random.randrange(0, np.iinfo(np.uint32).max)
+        }
+
+class NodeSeed(DreamTexturesNode):
+    bl_idname = "dream_textures.node_seed"
+    bl_label = "Seed"
+
+    seed: bpy.props.StringProperty(name="", default="", update=seed_clamp)
+
+    def init(self, context):
+        self.outputs.new("NodeSocketInt", "Value")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "seed")
+
+    def execute(self, context):
+        return {
+            'Value': int(self.seed)
         }
 
 class NodeClamp(DreamTexturesNode):

--- a/engine/nodes/utility_nodes.py
+++ b/engine/nodes/utility_nodes.py
@@ -64,6 +64,21 @@ class NodeRandomValue(DreamTexturesNode):
             'Value': random.randrange(min, max)
         }
 
+class NodeRandomSeed(DreamTexturesNode):
+    bl_idname = "dream_textures.node_random_seed"
+    bl_label = "Random Seed"
+
+    def init(self, context):
+        self.outputs.new("NodeSocketInt", "Value")
+
+    def draw_buttons(self, context, layout):
+        pass
+
+    def execute(self, context):
+        return {
+            'Value': random.randrange(0, np.iinfo(np.uint32).max)
+        }
+
 class NodeClamp(DreamTexturesNode):
     bl_idname = "dream_textures.node_clamp"
     bl_label = "Clamp"


### PR DESCRIPTION
This adds built-in support for the segmentation ControlNet model. Apply labels to objects then use them in the render engine to produce segmentation maps that use the ADE20K classes/colors.

![segmentation](https://user-images.githubusercontent.com/13581484/227732212-e5696d8d-59e8-4c46-85ec-0321cf34637c.png)
![donut](https://user-images.githubusercontent.com/13581484/227732247-02078e6a-b800-40d5-af93-fdc424c29f96.png)
<img width="1162" alt="Screenshot 2023-03-20 at 6 03 59 PM" src="https://user-images.githubusercontent.com/13581484/227732243-1c18b270-2fa2-446b-90bc-495ed41b0567.png">
