### PR TITLE
ControlNet + Inpainting Projection

### DIFF
--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -180,6 +180,7 @@ class DreamTexture(bpy.types.Operator):
             if len(generated_args['control_net']) > 0:
                 f = gen.control_net(
                     image=init_image,
+                    inpaint=generated_args['init_img_action'] == 'inpaint',
                     **generated_args
                 )
             elif init_image is not None:


### PR DESCRIPTION
## Usage
Improved UI still needs to be created. For now:

1. Place cameras around a single object
2. Select the object and go into edit mode
3. In the projection panel, enable "Use ControlNet" and choose a depth ControlNet model
4. Ensure you have downloaded the models `runwayml/stable-diffusion-v1-5` and `runwayml/stable-diffusion-inpainting` as the model is currently hard-coded
5. Press "Project", Blender will hang while the generation occurs

## Method Overview

### For the first perspective

1. Generate the first angle with a depth ControlNet and text to image model.

https://github.com/carson-katri/dream-textures/blob/7884149f6cc09c820d4e16dd7964af6004e149d0/operators/project.py#L528-L537

![generation_result](https://user-images.githubusercontent.com/13581484/228088804-58570f61-e972-4448-b421-965e5f917949.png)

2. Bake the texture to the result.

https://github.com/carson-katri/dream-textures/blob/7884149f6cc09c820d4e16dd7964af6004e149d0/operators/project.py#L538

### For subsequent perspectives

1. Create a mask for faces oriented toward this camera, in both projected and baked forms.

https://github.com/carson-katri/dream-textures/blob/7884149f6cc09c820d4e16dd7964af6004e149d0/operators/project.py#L353

![mask](https://user-images.githubusercontent.com/13581484/228088881-67615f6c-9c4b-4f62-b083-3bdf035f3a59.png)

2. Capture the object with the latest result texture from this new perspective, and use the mask as the alpha channel.

https://github.com/carson-katri/dream-textures/blob/7884149f6cc09c820d4e16dd7964af6004e149d0/operators/project.py#L510-L511

3. Inpaint using the masked `color` with a depth ControlNet and inpainting model.

https://github.com/carson-katri/dream-textures/blob/7884149f6cc09c820d4e16dd7964af6004e149d0/operators/project.py#L512-L523

![inpaint_result](https://user-images.githubusercontent.com/13581484/228089976-3c4f7c96-a29b-438d-9e19-f43402a722de.png)

7. Bake and merge with the latest result texture.

https://github.com/carson-katri/dream-textures/blob/7884149f6cc09c820d4e16dd7964af6004e149d0/operators/project.py#L524-L526


## Results
I have not thoroughly tested this, but here is one result using only two camera angles.

<img width="490" alt="Screenshot 2023-03-27 at 7 21 58 PM" src="https://user-images.githubusercontent.com/13581484/228089914-3da17bb9-870c-4178-ac3a-248f646d225d.png">

Coherence between the two sides is better than if two completely random generations were merged.