### PR TITLE
Add CFG End Optimization

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -88,6 +88,8 @@ if current_process().name != "__actor__":
         bpy.types.Scene.dream_textures_history_selection_preview = bpy.props.StringProperty(name="", default="", get=get_selection_preview, set=lambda _, __: None)
         bpy.types.Scene.dream_textures_progress = bpy.props.IntProperty(name="", default=0, min=0, max=0)
         bpy.types.Scene.dream_textures_info = bpy.props.StringProperty(name="Info")
+        import time
+        bpy.types.Scene.dream_textures_last_execution_time = bpy.props.StringProperty(name="Last Execution Time", default=f"{time.time()} seconds")
 
         bpy.types.Scene.dream_textures_viewport_enabled = BoolProperty(name="Viewport Enabled", default=False)
         bpy.types.Scene.dream_textures_render_properties_enabled = BoolProperty(default=False)

--- a/__init__.py
+++ b/__init__.py
@@ -88,7 +88,6 @@ if current_process().name != "__actor__":
         bpy.types.Scene.dream_textures_history_selection_preview = bpy.props.StringProperty(name="", default="", get=get_selection_preview, set=lambda _, __: None)
         bpy.types.Scene.dream_textures_progress = bpy.props.IntProperty(name="", default=0, min=0, max=0)
         bpy.types.Scene.dream_textures_info = bpy.props.StringProperty(name="Info")
-        import time
         bpy.types.Scene.dream_textures_last_execution_time = bpy.props.StringProperty(name="Last Execution Time", default="")
 
         bpy.types.Scene.dream_textures_viewport_enabled = BoolProperty(name="Viewport Enabled", default=False)

--- a/__init__.py
+++ b/__init__.py
@@ -89,7 +89,7 @@ if current_process().name != "__actor__":
         bpy.types.Scene.dream_textures_progress = bpy.props.IntProperty(name="", default=0, min=0, max=0)
         bpy.types.Scene.dream_textures_info = bpy.props.StringProperty(name="Info")
         import time
-        bpy.types.Scene.dream_textures_last_execution_time = bpy.props.StringProperty(name="Last Execution Time", default=f"{time.time()} seconds")
+        bpy.types.Scene.dream_textures_last_execution_time = bpy.props.StringProperty(name="Last Execution Time", default="")
 
         bpy.types.Scene.dream_textures_viewport_enabled = BoolProperty(name="Viewport Enabled", default=False)
         bpy.types.Scene.dream_textures_render_properties_enabled = BoolProperty(default=False)

--- a/generator_process/actions/control_net.py
+++ b/generator_process/actions/control_net.py
@@ -357,7 +357,10 @@ def control_net(
                             if do_classifier_free_guidance and (i / len(timesteps)) >= kwargs['cfg_end']:
                                 do_classifier_free_guidance = False
                                 prompt_embeds = prompt_embeds[prompt_embeds.size(0) // 2:]
-                                image = [i[None, 0] for i in image]
+                                image = [i[i.size(0) // 2:] for i in image]
+                                if mask is not None:
+                                    mask = mask[mask.size(0) // 2:]
+                                    masked_image_latents = masked_image_latents[masked_image_latents.size(0) // 2:]
                             # expand the latents if we are doing classifier free guidance
                             latent_model_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents
                             latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)

--- a/generator_process/actions/control_net.py
+++ b/generator_process/actions/control_net.py
@@ -354,9 +354,9 @@ def control_net(
                     with self.progress_bar(total=num_inference_steps) as progress_bar:
                         for i, t in enumerate(timesteps):
                             # NOTE: Modified to support disabling CFG
-                            if (i / len(timesteps)) >= kwargs['cfg_end']:
+                            if do_classifier_free_guidance and (i / len(timesteps)) >= kwargs['cfg_end']:
                                 do_classifier_free_guidance = False
-                                prompt_embeds = prompt_embeds[None, 0]
+                                prompt_embeds = prompt_embeds[prompt_embeds.size(0) // 2:]
                                 image = [i[None, 0] for i in image]
                             # expand the latents if we are doing classifier free guidance
                             latent_model_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents

--- a/generator_process/actions/control_net.py
+++ b/generator_process/actions/control_net.py
@@ -353,6 +353,11 @@ def control_net(
                     num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order
                     with self.progress_bar(total=num_inference_steps) as progress_bar:
                         for i, t in enumerate(timesteps):
+                            # NOTE: Modified to support disabling CFG
+                            if (i / len(timesteps)) >= kwargs['cfg_end']:
+                                do_classifier_free_guidance = False
+                                prompt_embeds = prompt_embeds[None, 0]
+                                image = [i[None, 0] for i in image]
                             # expand the latents if we are doing classifier free guidance
                             latent_model_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents
                             latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)
@@ -522,7 +527,8 @@ def control_net(
                     return_dict=True,
                     callback=None,
                     callback_steps=1,
-                    step_preview_mode=step_preview_mode
+                    step_preview_mode=step_preview_mode,
+                    cfg_end=optimizations.cfg_end
                 )
         case Pipeline.STABILITY_SDK:
             import stability_sdk

--- a/generator_process/actions/depth_to_image.py
+++ b/generator_process/actions/depth_to_image.py
@@ -278,10 +278,10 @@ def depth_to_image(
                     with self.progress_bar(total=num_inference_steps) as progress_bar:
                         for i, t in enumerate(timesteps):
                             # NOTE: Modified to support disabling CFG
-                            if (i / len(timesteps)) >= kwargs['cfg_end']:
+                            if do_classifier_free_guidance and (i / len(timesteps)) >= kwargs['cfg_end']:
                                 do_classifier_free_guidance = False
-                                text_embeddings = text_embeddings[None, 0]
-                                depth = depth[None, 0]
+                                text_embeddings = text_embeddings[text_embeddings.size(0) // 2:]
+                                depth = depth[depth.size(0) // 2:]
                             # expand the latents if we are doing classifier free guidance
                             latent_model_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents
 

--- a/generator_process/actions/depth_to_image.py
+++ b/generator_process/actions/depth_to_image.py
@@ -263,10 +263,6 @@ def depth_to_image(
                         do_classifier_free_guidance,
                     )
 
-                    if kwargs['cfg_end'] < 1:
-                        first_embeddings = text_embeddings[None, 0]
-                        first_depth = depth[None, 0]
-
                     # 8. Check that sizes of mask, masked image and latents match
                     num_channels_depth = depth.shape[1]
                     if num_channels_latents + num_channels_depth != self.unet.config.in_channels:
@@ -281,19 +277,23 @@ def depth_to_image(
                     num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order
                     with self.progress_bar(total=num_inference_steps) as progress_bar:
                         for i, t in enumerate(timesteps):
-                            use_cfg = do_classifier_free_guidance and (i / len(timesteps)) < kwargs['cfg_end']
+                            # NOTE: Modified to support disabling CFG
+                            if (i / len(timesteps)) >= kwargs['cfg_end']:
+                                do_classifier_free_guidance = False
+                                text_embeddings = text_embeddings[None, 0]
+                                depth = depth[None, 0]
                             # expand the latents if we are doing classifier free guidance
-                            latent_model_input = torch.cat([latents] * 2) if use_cfg else latents
+                            latent_model_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents
 
                             # concat latents, mask, masked_image_latents in the channel dimension
                             latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)
-                            latent_model_input = torch.cat([latent_model_input, depth if use_cfg else first_depth], dim=1)
+                            latent_model_input = torch.cat([latent_model_input, depth], dim=1)
 
                             # predict the noise residual
-                            noise_pred = self.unet(latent_model_input, t, encoder_hidden_states=text_embeddings if use_cfg else first_embeddings).sample
+                            noise_pred = self.unet(latent_model_input, t, encoder_hidden_states=text_embeddings).sample
 
                             # perform guidance
-                            if use_cfg:
+                            if do_classifier_free_guidance:
                                 noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
                                 noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
 

--- a/generator_process/actions/image_to_image.py
+++ b/generator_process/actions/image_to_image.py
@@ -106,9 +106,9 @@ def image_to_image(
                     with self.progress_bar(total=num_inference_steps) as progress_bar:
                         for i, t in enumerate(timesteps):
                             # NOTE: Modified to support disabling CFG
-                            if (i / len(timesteps)) >= kwargs['cfg_end']:
+                            if do_classifier_free_guidance and (i / len(timesteps)) >= kwargs['cfg_end']:
                                 do_classifier_free_guidance = False
-                                text_embeddings = text_embeddings[None, 0]
+                                text_embeddings = text_embeddings[text_embeddings.size(0) // 2:]
                             # expand the latents if we are doing classifier free guidance
                             latent_model_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents
                             latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)

--- a/generator_process/actions/inpaint.py
+++ b/generator_process/actions/inpaint.py
@@ -127,6 +127,10 @@ def inpaint(
                         generator,
                         do_classifier_free_guidance,
                     )
+                    if kwargs['cfg_end'] < 1:
+                        first_embeddings = text_embeddings[None, 0]
+                        first_mask = mask[None, 0]
+                        first_masked_image_latents = masked_image_latents[None, 0]
 
                     # 8. Check that sizes of mask, masked image and latents match
                     num_channels_mask = mask.shape[1]
@@ -143,18 +147,19 @@ def inpaint(
                     num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order
                     with self.progress_bar(total=num_inference_steps) as progress_bar:
                         for i, t in enumerate(timesteps):
+                            use_cfg = do_classifier_free_guidance and (i / len(timesteps)) < kwargs['cfg_end']
                             # expand the latents if we are doing classifier free guidance
-                            latent_model_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents
+                            latent_model_input = torch.cat([latents] * 2) if use_cfg else latents
 
                             # concat latents, mask, masked_image_latents in the channel dimension
                             latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)
-                            latent_model_input = torch.cat([latent_model_input, mask, masked_image_latents], dim=1)
+                            latent_model_input = torch.cat([latent_model_input, mask if use_cfg else first_mask, masked_image_latents if use_cfg else first_masked_image_latents], dim=1)
 
                             # predict the noise residual
-                            noise_pred = self.unet(latent_model_input, t, encoder_hidden_states=text_embeddings).sample
+                            noise_pred = self.unet(latent_model_input, t, encoder_hidden_states=text_embeddings if use_cfg else first_embeddings).sample
 
                             # perform guidance
-                            if do_classifier_free_guidance:
+                            if use_cfg:
                                 noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
                                 noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
 
@@ -248,7 +253,8 @@ def inpaint(
                     return_dict=True,
                     callback=None,
                     callback_steps=1,
-                    step_preview_mode=step_preview_mode
+                    step_preview_mode=step_preview_mode,
+                    cfg_end=optimizations.cfg_end
                 )
         case Pipeline.STABILITY_SDK:
             import stability_sdk.client

--- a/generator_process/actions/inpaint.py
+++ b/generator_process/actions/inpaint.py
@@ -144,11 +144,11 @@ def inpaint(
                     with self.progress_bar(total=num_inference_steps) as progress_bar:
                         for i, t in enumerate(timesteps):
                             # NOTE: Modified to support disabling CFG
-                            if (i / len(timesteps)) >= kwargs['cfg_end']:
+                            if do_classifier_free_guidance and (i / len(timesteps)) >= kwargs['cfg_end']:
                                 do_classifier_free_guidance = False
-                                text_embeddings = text_embeddings[None, 0]
-                                mask = mask[None, 0]
-                                masked_image_latents = masked_image_latents[None, 0]
+                                text_embeddings = text_embeddings[text_embeddings.size(0) // 2:]
+                                mask = mask[mask.size(0) // 2:]
+                                masked_image_latents = masked_image_latents[masked_image_latents.size(0) // 2:]
                             # expand the latents if we are doing classifier free guidance
                             latent_model_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents
 

--- a/generator_process/actions/prompt_to_image.py
+++ b/generator_process/actions/prompt_to_image.py
@@ -543,9 +543,9 @@ def prompt_to_image(
                     # 7. Denoising loop
                     for i, t in enumerate(self.progress_bar(timesteps)):
                         # NOTE: Modified to support disabling CFG
-                        if (i / len(timesteps)) >= kwargs['cfg_end']:
+                        if do_classifier_free_guidance and (i / len(timesteps)) >= kwargs['cfg_end']:
                             do_classifier_free_guidance = False
-                            text_embeddings = text_embeddings[None, 0]
+                            text_embeddings = text_embeddings[text_embeddings.size(0) // 2:]
 
                         # expand the latents if we are doing classifier free guidance
                         latent_model_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents

--- a/generator_process/actions/prompt_to_image.py
+++ b/generator_process/actions/prompt_to_image.py
@@ -520,7 +520,7 @@ def prompt_to_image(
                         prompt, device, num_images_per_prompt, do_classifier_free_guidance, negative_prompt
                     )
                     if kwargs['cfg_end'] < 1:
-                        zero_embeddings = torch.zeros_like(text_embeddings)
+                        first_embeddings = text_embeddings[None, 0]
 
                     # 4. Prepare timesteps
                     self.scheduler.set_timesteps(num_inference_steps, device=device)
@@ -550,7 +550,7 @@ def prompt_to_image(
                         latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)
 
                         # predict the noise residual
-                        noise_pred = self.unet(latent_model_input, t, encoder_hidden_states=text_embeddings if use_cfg else zero_embeddings).sample
+                        noise_pred = self.unet(latent_model_input, t, encoder_hidden_states=text_embeddings if use_cfg else first_embeddings).sample
 
                         # perform guidance
                         if use_cfg:

--- a/generator_process/actions/prompt_to_image.py
+++ b/generator_process/actions/prompt_to_image.py
@@ -519,8 +519,6 @@ def prompt_to_image(
                     text_embeddings = self._encode_prompt(
                         prompt, device, num_images_per_prompt, do_classifier_free_guidance, negative_prompt
                     )
-                    if kwargs['cfg_end'] < 1:
-                        first_embeddings = text_embeddings[None, 0]
 
                     # 4. Prepare timesteps
                     self.scheduler.set_timesteps(num_inference_steps, device=device)
@@ -544,16 +542,20 @@ def prompt_to_image(
 
                     # 7. Denoising loop
                     for i, t in enumerate(self.progress_bar(timesteps)):
-                        use_cfg = do_classifier_free_guidance and (i / len(timesteps)) < kwargs['cfg_end']
+                        # NOTE: Modified to support disabling CFG
+                        if (i / len(timesteps)) >= kwargs['cfg_end']:
+                            do_classifier_free_guidance = False
+                            text_embeddings = text_embeddings[None, 0]
+
                         # expand the latents if we are doing classifier free guidance
-                        latent_model_input = torch.cat([latents] * 2) if use_cfg else latents
+                        latent_model_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents
                         latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)
 
                         # predict the noise residual
-                        noise_pred = self.unet(latent_model_input, t, encoder_hidden_states=text_embeddings if use_cfg else first_embeddings).sample
+                        noise_pred = self.unet(latent_model_input, t, encoder_hidden_states=text_embeddings).sample
 
                         # perform guidance
-                        if use_cfg:
+                        if do_classifier_free_guidance:
                             noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
                             noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
 

--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -93,7 +93,7 @@ class DreamTexture(bpy.types.Operator):
         execution_start = time.time()
         def step_callback(_, step_image: ImageGenerationResult):
             nonlocal last_data_block
-            scene.dream_textures_last_execution_time = f"{time.time() - execution_start} seconds"
+            scene.dream_textures_last_execution_time = f"{time.time() - execution_start:.2f} seconds"
             if step_image.final:
                 return
             scene.dream_textures_progress = step_image.step

--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -10,6 +10,7 @@ from ..prompt_engineering import *
 from ..generator_process import Generator
 from ..generator_process.actions.prompt_to_image import ImageGenerationResult, Pipeline
 from ..generator_process.actions.huggingface_hub import ModelType
+import time
 
 def bpy_image(name, width, height, pixels, existing_image):
     if existing_image is not None and (existing_image.size[0] != width or existing_image.size[1] != height):
@@ -89,8 +90,10 @@ class DreamTexture(bpy.types.Operator):
         scene.dream_textures_info = "Starting..."
 
         last_data_block = None
+        execution_start = time.time()
         def step_callback(_, step_image: ImageGenerationResult):
             nonlocal last_data_block
+            scene.dream_textures_last_execution_time = f"{time.time() - execution_start} seconds"
             if step_image.final:
                 return
             scene.dream_textures_progress = step_image.step

--- a/property_groups/dream_prompt.py
+++ b/property_groups/dream_prompt.py
@@ -223,7 +223,7 @@ optimization("vae_tiling", property=EnumProperty, items=(
 ), default=0, name="VAE Tiling", description="Decodes generated images in tiled regions to reduce memory usage in exchange for longer decode time and less accurate colors.\nCan allow for generating larger images that would otherwise run out of memory on the final step")
 optimization("vae_tile_size", min=1, name="VAE Tile Size", description="Width and height measurement of tiles. Smaller sizes are more likely to cause inaccurate colors and other undesired artifacts")
 optimization("vae_tile_blend", min=0, name="VAE Tile Blend", description="Minimum amount of how much each edge of a tile will intersect its adjacent tile")
-optimization("cfg_end", name="CFG End", description="The percentage of steps to complete before disabling classifier-free guidance")
+optimization("cfg_end", name="CFG End", min=0, max=1, description="The percentage of steps to complete before disabling classifier-free guidance")
 optimization("cpu_only", name="CPU Only", description="Disables GPU acceleration and is extremely slow")
 
 def map_structure_token_items(value):

--- a/property_groups/dream_prompt.py
+++ b/property_groups/dream_prompt.py
@@ -186,6 +186,8 @@ def optimization(optim, property=None, **kwargs):
                 property = BoolProperty
             case int():
                 property = IntProperty
+            case float():
+                property = FloatProperty
             case _:
                 raise TypeError(f"{optim} cannot infer optimization property from {type(kwargs['default'])}")
     attributes[f"optimizations_{optim}"] = property(**kwargs)
@@ -221,6 +223,7 @@ optimization("vae_tiling", property=EnumProperty, items=(
 ), default=0, name="VAE Tiling", description="Decodes generated images in tiled regions to reduce memory usage in exchange for longer decode time and less accurate colors.\nCan allow for generating larger images that would otherwise run out of memory on the final step")
 optimization("vae_tile_size", min=1, name="VAE Tile Size", description="Width and height measurement of tiles. Smaller sizes are more likely to cause inaccurate colors and other undesired artifacts")
 optimization("vae_tile_blend", min=0, name="VAE Tile Blend", description="Minimum amount of how much each edge of a tile will intersect its adjacent tile")
+optimization("cfg_end", name="CFG End", description="The percentage of steps to complete before disabling classifier-free guidance")
 optimization("cpu_only", name="CPU Only", description="Disables GPU acceleration and is extremely slow")
 
 def map_structure_token_items(value):

--- a/ui/panels/dream_texture.py
+++ b/ui/panels/dream_texture.py
@@ -308,6 +308,9 @@ def optimization_panels(sub_panel, space_type, get_prompt, parent_id=""):
             optimization("half_precision")
             optimization("channels_last_memory_format")
             optimization("batch_size")
+            optimization("cfg_end")
+            if prompt.optimizations_cfg_end:
+                optimization("cfg_end_ratio")
     yield SpeedOptimizationPanel
 
     class MemoryOptimizationPanel(sub_panel):
@@ -379,9 +382,10 @@ def actions_panel(sub_panel, space_type, get_prompt):
             row.operator(ReleaseGenerator.bl_idname, icon="X", text="")
 
             if context.scene.dream_textures_last_execution_time != "":
-                t = layout.label(text=context.scene.dream_textures_last_execution_time, icon="SORTTIME")
-                t.scale_x = 0.5
-                t.scale_y = 0.5
+                r = layout.row()
+                r.scale_x = 0.5
+                r.scale_y = 0.5
+                r.label(text=context.scene.dream_textures_last_execution_time, icon="SORTTIME")
 
             # Validation
             try:

--- a/ui/panels/dream_texture.py
+++ b/ui/panels/dream_texture.py
@@ -378,6 +378,11 @@ def actions_panel(sub_panel, space_type, get_prompt):
                 row.operator(CancelGenerator.bl_idname, icon="CANCEL", text="")
             row.operator(ReleaseGenerator.bl_idname, icon="X", text="")
 
+            if context.scene.dream_textures_last_execution_time != "":
+                t = layout.label(text=context.scene.dream_textures_last_execution_time, icon="SORTTIME")
+                t.scale_x = 0.5
+                t.scale_y = 0.5
+
             # Validation
             try:
                 prompt.validate(context)

--- a/ui/panels/dream_texture.py
+++ b/ui/panels/dream_texture.py
@@ -309,8 +309,6 @@ def optimization_panels(sub_panel, space_type, get_prompt, parent_id=""):
             optimization("channels_last_memory_format")
             optimization("batch_size")
             optimization("cfg_end")
-            if prompt.optimizations_cfg_end:
-                optimization("cfg_end_ratio")
     yield SpeedOptimizationPanel
 
     class MemoryOptimizationPanel(sub_panel):


### PR DESCRIPTION
This adds a new optimization that limits the number of steps classifier-free guidance is performed on.

Using a `cfg_end` value of `0.5` reduced inference time by around 22% in my tests.

> As seen here: https://twitter.com/Birchlabs/status/1640033271512702977

<table>
<tr>
  <th>1.0 (disabled)</th>
  <th>0.5</th>
</tr>
<tr>
  <td>

![ocean (cfg_end 1)](https://user-images.githubusercontent.com/13581484/228100755-8e080a03-41db-4086-862e-8834ff59f5db.png)

</td>
  <td>

![ocean (cfg_end 0 5)](https://user-images.githubusercontent.com/13581484/228100871-8b5dc3c9-e4a2-4940-a4fa-e975b861589c.png)

  </td>
</tr>
</table>
