### PR TITLE
Bump Torch ROCm version to 2.0

### DIFF
--- a/requirements/linux-rocm.txt
+++ b/requirements/linux-rocm.txt
@@ -3,8 +3,8 @@ transformers
 accelerate
 huggingface_hub
 
---extra-index-url https://download.pytorch.org/whl/rocm5.2/
-torch>=1.13
+--extra-index-url https://download.pytorch.org/whl/rocm5.4.2/
+torch>=2.0
 
 # Original SD checkpoint conversion
 pytorch-lightning


### PR DESCRIPTION
Currently we will miss ROCm wheel and install Torch-CUDA with linux-rocm.txt line "torch>=1.13" so I bumped the --extra-index-url to the new ROCm and the version to 2.0