### PR TITLE
Hide NodeResizeImage and NodeImageFile if not v3.5

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -17,45 +17,57 @@ class DreamTexturesNodeCategory(nodeitems_utils.NodeCategory):
     def poll(cls, context):
         return context.space_data.tree_type == DreamTexturesNodeTree.__name__
 
+pipeline_items = [
+    nodeitems_utils.NodeItem(NodeStableDiffusion.bl_idname),
+    nodeitems_utils.NodeItem(NodeControlNet.bl_idname),
+]
+
+input_items = [
+    nodeitems_utils.NodeItem(NodeInteger.bl_idname),
+    nodeitems_utils.NodeItem(NodeString.bl_idname),
+    nodeitems_utils.NodeItem(NodeImage.bl_idname),
+    nodeitems_utils.NodeItem(NodeCollection.bl_idname),
+    nodeitems_utils.NodeItem(NodeRenderProperties.bl_idname),
+]
+if bpy.app.version >= (3, 5, 0):
+    input_items.append(nodeitems_utils.NodeItem(NodeImageFile.bl_idname))
+
+utility_items = [
+    nodeitems_utils.NodeItem(NodeMath.bl_idname),
+    nodeitems_utils.NodeItem(NodeRandomValue.bl_idname),
+    nodeitems_utils.NodeItem(NodeRandomSeed.bl_idname),
+    nodeitems_utils.NodeItem(NodeSeed.bl_idname),
+    nodeitems_utils.NodeItem(NodeClamp.bl_idname),
+    nodeitems_utils.NodeItem(NodeFramePath.bl_idname),
+    nodeitems_utils.NodeItem(NodeCropImage.bl_idname),
+    nodeitems_utils.NodeItem(NodeJoinImages.bl_idname),
+    nodeitems_utils.NodeItem(NodeColorCorrect.bl_idname),
+    nodeitems_utils.NodeItem(NodeSeparateColor.bl_idname),
+    nodeitems_utils.NodeItem(NodeCombineColor.bl_idname),
+    nodeitems_utils.NodeItem(NodeSwitch.bl_idname),
+    nodeitems_utils.NodeItem(NodeCompare.bl_idname),
+    nodeitems_utils.NodeItem(NodeReplaceString.bl_idname),
+]
+if bpy.app.version >= (3, 5, 0):
+    utility_items.append(nodeitems_utils.NodeItem(NodeResizeImage.bl_idname))
+
+annotations_items = [
+    nodeitems_utils.NodeItem(NodeAnnotationDepth.bl_idname),
+    nodeitems_utils.NodeItem(NodeAnnotationOpenPose.bl_idname),
+    nodeitems_utils.NodeItem(NodeAnnotationADE20K.bl_idname),
+    nodeitems_utils.NodeItem(NodeAnnotationViewport.bl_idname),
+]
+
+group_items = [
+    nodeitems_utils.NodeItem(bpy.types.NodeGroupOutput.__name__),
+]
+
 categories = [
-    DreamTexturesNodeCategory("DREAM_TEXTURES_PIPELINE", "Pipeline", items = [
-        nodeitems_utils.NodeItem(NodeStableDiffusion.bl_idname),
-        nodeitems_utils.NodeItem(NodeControlNet.bl_idname),
-    ]),
-    DreamTexturesNodeCategory("DREAM_TEXTURES_INPUT", "Input", items = [
-        nodeitems_utils.NodeItem(NodeInteger.bl_idname),
-        nodeitems_utils.NodeItem(NodeString.bl_idname),
-        nodeitems_utils.NodeItem(NodeImage.bl_idname),
-        nodeitems_utils.NodeItem(NodeImageFile.bl_idname),
-        nodeitems_utils.NodeItem(NodeCollection.bl_idname),
-        nodeitems_utils.NodeItem(NodeRenderProperties.bl_idname),
-    ]),
-    DreamTexturesNodeCategory("DREAM_TEXTURES_UTILITY", "Utilities", items = [
-        nodeitems_utils.NodeItem(NodeMath.bl_idname),
-        nodeitems_utils.NodeItem(NodeRandomValue.bl_idname),
-        nodeitems_utils.NodeItem(NodeRandomSeed.bl_idname),
-        nodeitems_utils.NodeItem(NodeSeed.bl_idname),
-        nodeitems_utils.NodeItem(NodeClamp.bl_idname),
-        nodeitems_utils.NodeItem(NodeFramePath.bl_idname),
-        nodeitems_utils.NodeItem(NodeCropImage.bl_idname),
-        nodeitems_utils.NodeItem(NodeResizeImage.bl_idname),
-        nodeitems_utils.NodeItem(NodeJoinImages.bl_idname),
-        nodeitems_utils.NodeItem(NodeColorCorrect.bl_idname),
-        nodeitems_utils.NodeItem(NodeSeparateColor.bl_idname),
-        nodeitems_utils.NodeItem(NodeCombineColor.bl_idname),
-        nodeitems_utils.NodeItem(NodeSwitch.bl_idname),
-        nodeitems_utils.NodeItem(NodeCompare.bl_idname),
-        nodeitems_utils.NodeItem(NodeReplaceString.bl_idname),
-    ]),
-    DreamTexturesNodeCategory("DREAM_TEXTURES_ANNOTATIONS", "Annotations", items = [
-        nodeitems_utils.NodeItem(NodeAnnotationDepth.bl_idname),
-        nodeitems_utils.NodeItem(NodeAnnotationOpenPose.bl_idname),
-        nodeitems_utils.NodeItem(NodeAnnotationADE20K.bl_idname),
-        nodeitems_utils.NodeItem(NodeAnnotationViewport.bl_idname),
-    ]),
-    DreamTexturesNodeCategory("DREAM_TEXTURES_GROUP", "Group", items = [
-        nodeitems_utils.NodeItem(bpy.types.NodeGroupOutput.__name__),
-    ]),
+    DreamTexturesNodeCategory("DREAM_TEXTURES_PIPELINE", "Pipeline", items=pipeline_items),
+    DreamTexturesNodeCategory("DREAM_TEXTURES_INPUT", "Input", items=input_items),
+    DreamTexturesNodeCategory("DREAM_TEXTURES_UTILITY", "Utilities", items=utility_items),
+    DreamTexturesNodeCategory("DREAM_TEXTURES_ANNOTATIONS", "Annotations", items=annotations_items),
+    DreamTexturesNodeCategory("DREAM_TEXTURES_GROUP", "Group", items=group_items),
 ]
 
 def register():


### PR DESCRIPTION
These files were not registered, but they were still present in the node categories. This commit follows the same hiding logic as in (un)registration.

This was my menu in 3.4, note the "Unknown" node
![image](https://user-images.githubusercontent.com/19956136/234165172-096d047d-94c4-4595-ad21-1e5f5e4ade6b.png)

I since upgraded to 3.5, but I wanted to fix this for other 3.4 users!