### PR TITLE
Add CoreML backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+__packaged__
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/community_backends/coreml/README.md
+++ b/community_backends/coreml/README.md
@@ -1,0 +1,4 @@
+# CoreML Backend
+Faster inference on Apple Silicon with [apple/ml-stable-diffusion](https://github.com/apple/ml-stable-diffusion).
+
+Converted mlpackages are stored in the directory specified by `DREAM_TEXTURES_COREML_HOME`, or `~/.cache/dream_textures_coreml` by default.

--- a/community_backends/coreml/__init__.py
+++ b/community_backends/coreml/__init__.py
@@ -1,0 +1,80 @@
+bl_info = {
+    "name": "CoreML Backend",
+    "blender": (3, 1, 0),
+    "category": "Paint",
+}
+
+from multiprocessing import current_process
+import site
+import sys
+import os
+
+def _load_dependencies():
+    site.addsitedir(os.path.join(os.path.dirname(os.path.realpath(__file__)), ".python_dependencies"))
+    deps = sys.path.pop(-1)
+    sys.path.insert(0, deps)
+
+if current_process().name == "__actor__":
+    _load_dependencies()
+else:
+    import bpy
+    from typing import Tuple
+    from dream_textures.api import Backend, Task, Model, Prompt, SeamlessAxes, StepPreviewMode, StepCallback, Callback
+    from dream_textures.diffusers_backend import DiffusersBackend
+    from .actor import CoreMLActor
+
+    class CoreMLBackend(Backend):
+        name = "CoreML"
+        description = "CPU/GPU/NE accelerated generation on Apple Silicon"
+
+        compute_unit: bpy.props.EnumProperty(
+            name="Compute Unit",
+            items=(
+                ('ALL', 'All', 'Use all compute units available, including the neural engine'),
+                ('CPU_ONLY', 'CPU', 'Limit the model to only use the CPU'),
+                ('CPU_AND_GPU', 'CPU and GPU', 'Use both the CPU and GPU, but not the neural engine'),
+                ('CPU_AND_NE', 'CPU and NE', 'Use both the CPU and neural engine, but not the GPU'),
+            )
+        )
+
+        def list_models(self, context):
+            return DiffusersBackend.list_models(self, context)
+        
+        def list_schedulers(self, context):
+            return [
+                "DDIM",
+                "DPM Solver Multistep",
+                "Euler Ancestral Discrete",
+                "Euler Discrete",
+                "LMS Discrete",
+                "PNDM"
+            ]
+
+        def draw_speed_optimizations(self, layout, context):
+            layout.prop(self, "compute_unit")
+
+        def generate(self, task: Task, model: Model, prompt: Prompt, size: Tuple[int, int] | None, seed: int, steps: int, guidance_scale: float, scheduler: str, seamless_axes: SeamlessAxes, step_preview_mode: StepPreviewMode, iterations: int, step_callback: StepCallback, callback: Callback):
+            gen: CoreMLActor = CoreMLActor.shared()
+            gen.generate(
+                model=model.id.replace('models--', '').replace('--', '/'),
+                prompt=prompt.positive,
+                negative_prompt=prompt.negative,
+                size=size,
+                seed=seed,
+                steps=steps,
+                guidance_scale=guidance_scale,
+                scheduler=scheduler,
+                seamless_axes=seamless_axes,
+                step_preview_mode=step_preview_mode,
+                iterations=iterations,
+                compute_unit=self.compute_unit,
+                controlnet=None,
+                controlnet_inputs=[]
+            )
+            raise NotImplementedError()
+
+    def register():
+        bpy.utils.register_class(CoreMLBackend)
+
+    def unregister():
+        bpy.utils.unregister_class(CoreMLBackend)

--- a/community_backends/coreml/actor.py
+++ b/community_backends/coreml/actor.py
@@ -1,0 +1,103 @@
+import numpy as np
+from numpy.typing import NDArray
+from dream_textures.generator_process import Actor
+import os
+
+class CoreMLActor(Actor):
+    def generate(
+        self,
+        model: str,
+        prompt: str,
+        negative_prompt: str | None,
+        size: tuple[int, int],
+        seed: int,
+        steps: int,
+        guidance_scale: float,
+        scheduler: str,
+        seamless_axes: str,
+        step_preview_mode: str,
+        iterations: int,
+
+        compute_unit: str,
+        controlnet: list[str] | None,
+        controlnet_inputs: list[str]
+    ) -> NDArray:
+        from python_coreml_stable_diffusion import pipeline
+        from python_coreml_stable_diffusion import torch2coreml, unet
+
+        np.random.seed(seed)
+
+        # Initializing PyTorch pipe for reference configuration
+        from diffusers import StableDiffusionPipeline
+        pytorch_pipe = StableDiffusionPipeline.from_pretrained(model,
+                                                            use_auth_token=True)
+        # There is currently no UI for this, so remove it.
+        # This avoids wasting time converting and loading it.
+        pytorch_pipe.safety_checker = None
+        
+        mlpackage_cache = os.path.expanduser(
+            os.getenv("HF_HOME", os.path.join(os.getenv("XDG_CACHE_HOME", "~/.cache"), "dream_textures_coreml"))
+        )
+        mlpackage_dir = os.path.join(mlpackage_cache, model.replace('/', '_'))
+
+        if not os.path.exists(mlpackage_dir):
+            os.makedirs(mlpackage_dir, exist_ok=True)
+            class ConversionArgs:
+                model_version = model
+                compute_unit = 'ALL'
+                latent_h = None
+                latent_w = None
+                attention_implementation = unet.ATTENTION_IMPLEMENTATION_IN_EFFECT.name
+                o = mlpackage_dir
+                check_output_correctness = False
+                chunk_unet = False
+                quantize_weights_to_8bits = False
+                unet_support_controlnet = False
+                text_encoder_vocabulary_url = "https://huggingface.co/openai/clip-vit-base-patch32/resolve/main/vocab.json"
+                text_encoder_merges_url = "https://huggingface.co/openai/clip-vit-base-patch32/resolve/main/merges.txt"
+            conversion_args = ConversionArgs()
+            torch2coreml.convert_vae_decoder(pytorch_pipe, conversion_args)
+            print("VAE decoder converted")
+            torch2coreml.convert_vae_encoder(pytorch_pipe, conversion_args)
+            print("VAE encoder converted")
+            torch2coreml.convert_unet(pytorch_pipe, conversion_args)
+            print("U-Net converted")
+            torch2coreml.convert_text_encoder(pytorch_pipe, conversion_args)
+            print("Text encoder converted")
+
+        user_specified_scheduler = None
+        if scheduler is not None:
+            user_specified_scheduler = pipeline.SCHEDULER_MAP[
+                scheduler.replace(' ', '')].from_config(pytorch_pipe.scheduler.config)
+
+        coreml_pipe = pipeline.get_coreml_pipe(
+            pytorch_pipe=pytorch_pipe,
+            mlpackages_dir=mlpackage_dir,
+            model_version=model,
+            compute_unit=compute_unit,
+            scheduler_override=user_specified_scheduler,
+            controlnet_models=controlnet
+        )
+
+        if controlnet:
+            controlnet_cond = []
+            for i, _ in enumerate(controlnet):
+                image_path = controlnet_inputs[i]
+                image = pipeline.prepare_controlnet_cond(image_path, coreml_pipe.height, coreml_pipe.width)
+                controlnet_cond.append(image)
+        else:
+            controlnet_cond = None
+
+        # Beginning image generation.
+        image = coreml_pipe(
+            prompt=prompt,
+            height=coreml_pipe.height,
+            width=coreml_pipe.width,
+            num_inference_steps=steps,
+            guidance_scale=guidance_scale,
+            controlnet_cond=controlnet_cond,
+            negative_prompt=negative_prompt,
+        )
+
+        image["images"][0].save('test.png')
+        return image["images"][0]

--- a/community_backends/coreml/actor.py
+++ b/community_backends/coreml/actor.py
@@ -1,19 +1,28 @@
 import numpy as np
 from numpy.typing import NDArray
 from dream_textures.generator_process import Actor
+from dream_textures.generator_process.future import Future
+from dream_textures.generator_process.models import ImageGenerationResult
+from dream_textures.api import GenerationResult
 import os
+import random
+import gc
 
 class CoreMLActor(Actor):
+    invalidation_args = None
+    cached_pipe = None
+
     def generate(
         self,
         model: str,
         prompt: str,
         negative_prompt: str | None,
-        size: tuple[int, int],
-        seed: int,
+        size: tuple[int, int] | None,
+        seed: int | None,
         steps: int,
         guidance_scale: float,
         scheduler: str,
+
         seamless_axes: str,
         step_preview_mode: str,
         iterations: int,
@@ -21,83 +30,204 @@ class CoreMLActor(Actor):
         compute_unit: str,
         controlnet: list[str] | None,
         controlnet_inputs: list[str]
-    ) -> NDArray:
+    ):
+        future = Future()
+        yield future
+
+        import diffusers
         from python_coreml_stable_diffusion import pipeline
         from python_coreml_stable_diffusion import torch2coreml, unet
-
+        import torch
+        from PIL import ImageOps
+        
+        seed = random.randrange(0, np.iinfo(np.uint32).max) if seed is None else seed
         np.random.seed(seed)
 
-        # Initializing PyTorch pipe for reference configuration
-        from diffusers import StableDiffusionPipeline
-        pytorch_pipe = StableDiffusionPipeline.from_pretrained(model,
-                                                            use_auth_token=True)
-        # There is currently no UI for this, so remove it.
-        # This avoids wasting time converting and loading it.
-        pytorch_pipe.safety_checker = None
-        
-        mlpackage_cache = os.path.expanduser(
-            os.getenv("HF_HOME", os.path.join(os.getenv("XDG_CACHE_HOME", "~/.cache"), "dream_textures_coreml"))
-        )
-        mlpackage_dir = os.path.join(mlpackage_cache, model.replace('/', '_'))
+        new_invalidation_args = (model, scheduler, controlnet)
+        if self.cached_pipe is None or new_invalidation_args != self.invalidation_args:
+            self.invalidation_args = new_invalidation_args
 
-        if not os.path.exists(mlpackage_dir):
-            os.makedirs(mlpackage_dir, exist_ok=True)
-            class ConversionArgs:
-                model_version = model
-                compute_unit = 'ALL'
-                latent_h = None
-                latent_w = None
-                attention_implementation = unet.ATTENTION_IMPLEMENTATION_IN_EFFECT.name
-                o = mlpackage_dir
-                check_output_correctness = False
-                chunk_unet = False
-                quantize_weights_to_8bits = False
-                unet_support_controlnet = False
-                text_encoder_vocabulary_url = "https://huggingface.co/openai/clip-vit-base-patch32/resolve/main/vocab.json"
-                text_encoder_merges_url = "https://huggingface.co/openai/clip-vit-base-patch32/resolve/main/merges.txt"
-            conversion_args = ConversionArgs()
-            torch2coreml.convert_vae_decoder(pytorch_pipe, conversion_args)
-            print("VAE decoder converted")
-            torch2coreml.convert_vae_encoder(pytorch_pipe, conversion_args)
-            print("VAE encoder converted")
-            torch2coreml.convert_unet(pytorch_pipe, conversion_args)
-            print("U-Net converted")
-            torch2coreml.convert_text_encoder(pytorch_pipe, conversion_args)
-            print("Text encoder converted")
 
-        user_specified_scheduler = None
-        if scheduler is not None:
-            user_specified_scheduler = pipeline.SCHEDULER_MAP[
-                scheduler.replace(' ', '')].from_config(pytorch_pipe.scheduler.config)
+            future.add_response(GenerationResult(progress=1, total=1, title="Loading reference pipeline"))
 
-        coreml_pipe = pipeline.get_coreml_pipe(
-            pytorch_pipe=pytorch_pipe,
-            mlpackages_dir=mlpackage_dir,
-            model_version=model,
-            compute_unit=compute_unit,
-            scheduler_override=user_specified_scheduler,
-            controlnet_models=controlnet
-        )
+            # Initializing PyTorch pipe for reference configuration
+            from diffusers import StableDiffusionPipeline
+            pytorch_pipe = StableDiffusionPipeline.from_pretrained(model,
+                                                                use_auth_token=True)
+            # There is currently no UI for this, so remove it.
+            # This avoids wasting time converting and loading it.
+            pytorch_pipe.safety_checker = None
+            
+            mlpackage_cache = os.path.expanduser(
+                os.getenv("HF_HOME", os.path.join(os.getenv("XDG_CACHE_HOME", "~/.cache"), "dream_textures_coreml"))
+            )
+            mlpackage_dir = os.path.join(mlpackage_cache, model.replace('/', '_'))
+
+            if not os.path.exists(mlpackage_dir):
+                def step_title(i, model_type):
+                    future.add_response(GenerationResult(progress=i, total=4, title=f"Converting model to CoreML ({model_type})"))
+                os.makedirs(mlpackage_dir, exist_ok=True)
+                class ConversionArgs:
+                    model_version = model
+                    compute_unit = 'ALL'
+                    latent_h = None
+                    latent_w = None
+                    attention_implementation = unet.ATTENTION_IMPLEMENTATION_IN_EFFECT.name
+                    o = mlpackage_dir
+                    check_output_correctness = False
+                    chunk_unet = False
+                    quantize_weights_to_8bits = False
+                    unet_support_controlnet = False
+                    text_encoder_vocabulary_url = "https://huggingface.co/openai/clip-vit-base-patch32/resolve/main/vocab.json"
+                    text_encoder_merges_url = "https://huggingface.co/openai/clip-vit-base-patch32/resolve/main/merges.txt"
+                conversion_args = ConversionArgs()
+
+                step_title(1, "VAE decoder")
+                torch2coreml.convert_vae_decoder(pytorch_pipe, conversion_args)
+
+                step_title(2, "VAE encoder")
+                torch2coreml.convert_vae_encoder(pytorch_pipe, conversion_args)
+
+                step_title(3, "U-Net")
+                torch2coreml.convert_unet(pytorch_pipe, conversion_args)
+
+                step_title(4, "text encoder")
+                torch2coreml.convert_text_encoder(pytorch_pipe, conversion_args)
+
+            future.add_response(GenerationResult(progress=0, total=1, title=f"Loading converted CoreML pipeline"))
+
+            user_specified_scheduler = None
+            if scheduler is not None:
+                user_specified_scheduler = pipeline.SCHEDULER_MAP[
+                    scheduler.replace(' ', '')].from_config(pytorch_pipe.scheduler.config)
+
+            # NOTE: Modified to have a `callback` parameter.
+            def get_coreml_pipe(pytorch_pipe,
+                        mlpackages_dir,
+                        model_version,
+                        compute_unit,
+                        delete_original_pipe=True,
+                        scheduler_override=None,
+                        controlnet_models=None,
+                        callback=lambda model_name: None):
+                """ Initializes and returns a `CoreMLStableDiffusionPipeline` from an original
+                diffusers PyTorch pipeline
+                """
+                # Ensure `scheduler_override` object is of correct type if specified
+                if scheduler_override is not None:
+                    assert isinstance(scheduler_override, diffusers.SchedulerMixin)
+                    pipeline.logger.warning(
+                        "Overriding scheduler in pipeline: "
+                        f"Default={pytorch_pipe.scheduler}, Override={scheduler_override}")
+
+                # Gather configured tokenizer and scheduler attributes from the original pipe
+                coreml_pipe_kwargs = {
+                    "tokenizer": pytorch_pipe.tokenizer,
+                    "scheduler": pytorch_pipe.scheduler if scheduler_override is None else scheduler_override,
+                    "feature_extractor": pytorch_pipe.feature_extractor,
+                }
+
+                model_names_to_load = ["text_encoder", "unet", "vae_decoder"]
+                if getattr(pytorch_pipe, "safety_checker", None) is not None:
+                    model_names_to_load.append("safety_checker")
+                else:
+                    pipeline.logger.warning(
+                        f"Original diffusers pipeline for {model_version} does not have a safety_checker, "
+                        "Core ML pipeline will mirror this behavior.")
+                    coreml_pipe_kwargs["safety_checker"] = None
+
+                if delete_original_pipe:
+                    del pytorch_pipe
+                    gc.collect()
+                    pipeline.logger.info("Removed PyTorch pipe to reduce peak memory consumption")
+
+                if controlnet_models:
+                    model_names_to_load.remove("unet")
+                    callback("control-unet")
+                    coreml_pipe_kwargs["unet"] = pipeline._load_mlpackage(
+                        "control-unet",
+                        mlpackages_dir,
+                        model_version,
+                        compute_unit,
+                    )
+                    coreml_pipe_kwargs["controlnet"] = []
+                    for i, model_version in enumerate(controlnet_models):
+                        callback(f"controlnet-{i}")
+                        coreml_pipe_kwargs["controlnet"].append(
+                            pipeline._load_mlpackage_controlnet(
+                                mlpackages_dir, 
+                                model_version, 
+                                compute_unit,
+                            )
+                        )
+                else:
+                    coreml_pipe_kwargs["controlnet"] = None
+
+                # Load Core ML models
+                pipeline.logger.info(f"Loading Core ML models in memory from {mlpackages_dir}")
+                def load_package_with_callback(model_name):
+                    callback(model_name)
+                    return pipeline._load_mlpackage(
+                        model_name,
+                        mlpackages_dir,
+                        model_version,
+                        compute_unit,
+                    )
+                coreml_pipe_kwargs.update({
+                    model_name: load_package_with_callback(model_name)
+                    for model_name in model_names_to_load
+                })
+                pipeline.logger.info("Done.")
+
+                pipeline.logger.info("Initializing Core ML pipe for image generation")
+                coreml_pipe = pipeline.CoreMLStableDiffusionPipeline(**coreml_pipe_kwargs)
+                pipeline.logger.info("Done.")
+
+                return coreml_pipe
+
+            model_i = 1
+            def load_callback(model_name):
+                nonlocal model_i
+                future.add_response(GenerationResult(progress=model_i, total=3 + len(controlnet_inputs), title=f"Loading {model_name} mlpackage (this can take a while)"))
+                model_i += 1
+            self.cached_pipe = get_coreml_pipe(
+                pytorch_pipe=pytorch_pipe,
+                mlpackages_dir=mlpackage_dir,
+                model_version=model,
+                compute_unit=compute_unit,
+                scheduler_override=user_specified_scheduler,
+                controlnet_models=controlnet,
+                callback=load_callback
+            )
+
+        height = self.cached_pipe.height if size is None else size[1]
+        width = self.cached_pipe.width if size is None else size[0]
 
         if controlnet:
             controlnet_cond = []
             for i, _ in enumerate(controlnet):
                 image_path = controlnet_inputs[i]
-                image = pipeline.prepare_controlnet_cond(image_path, coreml_pipe.height, coreml_pipe.width)
+                image = pipeline.prepare_controlnet_cond(image_path, height, width)
                 controlnet_cond.append(image)
         else:
             controlnet_cond = None
 
         # Beginning image generation.
-        image = coreml_pipe(
+        generator = torch.Generator(device="cpu").manual_seed(seed)
+        def callback(i, t, latents):
+            preview = ImageGenerationResult.step_preview(self, step_preview_mode, width, height, torch.from_numpy(latents), generator, i)
+            image = next(iter(preview.images), None)
+            future.add_response(GenerationResult(progress=i, total=steps, image=image, seed=seed))
+        image = self.cached_pipe(
             prompt=prompt,
-            height=coreml_pipe.height,
-            width=coreml_pipe.width,
+            height=height,
+            width=width,
             num_inference_steps=steps,
             guidance_scale=guidance_scale,
             controlnet_cond=controlnet_cond,
             negative_prompt=negative_prompt,
+            callback=callback
         )
 
-        image["images"][0].save('test.png')
-        return image["images"][0]
+        future.add_response(GenerationResult(progress=steps, total=steps, image=np.asarray(ImageOps.flip(image["images"][0]).convert('RGBA'), dtype=np.float32) / 255., seed=seed))
+        future.set_done()

--- a/community_backends/coreml/preferences.py
+++ b/community_backends/coreml/preferences.py
@@ -1,0 +1,7 @@
+import bpy
+
+class CoreMLBackendPreferences(bpy.types.AddonPreferences):
+    bl_idname = __package__
+
+    def draw(self, context):
+        layout = self.layout

--- a/community_backends/coreml/requirements.txt
+++ b/community_backends/coreml/requirements.txt
@@ -1,0 +1,3 @@
+coremltools
+git+https://github.com/apple/ml-stable-diffusion@main#egg=python_coreml_stable_diffusion
+scipy

--- a/scripts/package_backend.py
+++ b/scripts/package_backend.py
@@ -1,0 +1,34 @@
+import argparse
+import subprocess
+from pathlib import Path
+import shutil
+import sys
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--backend", type=lambda p: Path(p).absolute())
+parser.add_argument("--output", type=lambda p: Path(p).absolute())
+parser.add_argument("--no-deps", action="store_true")
+parser.add_argument("--install", action="store_true")
+
+def main():
+    args = parser.parse_args()
+
+    # Copy the files into the packaged addon
+    shutil.copytree(args.backend, args.output / args.backend.name, dirs_exist_ok=True)    
+
+    if args.install:
+        # Install the dependencies into the package.
+        subprocess.run(
+            [
+                sys.executable, "-m", "pip", "install",
+                "-r", args.backend / "requirements.txt",
+                "--upgrade",
+                "--no-cache-dir",
+                "--target", args.output / args.backend.name / ".python_dependencies",
+            ] + (["--no-deps"] if args.no_deps else []),
+            check=True,
+            cwd=args.output
+        )
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This adds a new backend for macOS that uses [apple/ml-stable-diffusion](https://github.com/apple/ml-stable-diffusion). Models are converted to CoreML automatically on their first use.

To build the package backend, use the new `package_backend.py` script:

```sh
/Applications/Blender\ 3.5.app/Contents/Resources/3.5/python/bin/python3.10 scripts/package_backend.py --backend community_backends/coreml --output __packaged__
```

If the `requirements.txt` file within the backend is unchanged, it can be built faster with `--no-deps`.