### PR TITLE
Various UI Tweaks

### DIFF
--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -83,7 +83,7 @@ class DreamTexture(bpy.types.Operator):
 
         init_image = None
         if generated_args['use_init_img']:
-            get_source_image(context, generated_args['init_img_src'])
+            init_image = get_source_image(context, generated_args['init_img_src'])
         if init_image is not None:
             init_image = np.flipud(
                 (np.array(init_image.pixels) * 255)

--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -102,7 +102,7 @@ class DreamTexture(bpy.types.Operator):
                 image = step_image.tile_images()
                 last_data_block = bpy_image(f"Step {step_image.step}/{generated_args['steps']}", image.shape[1], image.shape[0], image.ravel(), last_data_block)
                 for area in screen.areas:
-                    if area.type == 'IMAGE_EDITOR':
+                    if area.type == 'IMAGE_EDITOR' and not area.spaces.active.use_image_pin:
                         area.spaces.active.image = last_data_block
 
         iteration = 0
@@ -134,7 +134,7 @@ class DreamTexture(bpy.types.Operator):
                     texture_node.location = node_anchor + node_size * ((iteration % iteration_square), -(iteration // iteration_square))
                     nodes.active = texture_node
                 for area in screen.areas:
-                    if area.type == 'IMAGE_EDITOR':
+                    if area.type == 'IMAGE_EDITOR' and not area.spaces.active.use_image_pin:
                         area.spaces.active.image = image
                 scene.dream_textures_prompt.seed = str(seed) # update property in case seed was sourced randomly or from hash
                 # create a hash from the Blender image datablock to use as unique ID of said image and store it in the prompt history

--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -119,11 +119,12 @@ class DreamTexture(bpy.types.Operator):
         iteration = 0
         iteration_limit = len(file_batch_lines) if is_file_batch else generated_args['iterations']
         iteration_square = math.ceil(math.sqrt(iteration_limit))
-        node_pad = np.array((10, 10))
-        node_size = np.array((250, 287)) + node_pad
+        node_pad = np.array((20, 20))
+        node_size = np.array((240, 277)) + node_pad
         if node_tree is not None:
+            # keep image nodes grid centered but don't go beyond top and left sides of nodes editor
             node_anchor = node_tree_center + node_size * 0.5 * (-iteration_square, (iteration_limit-1) // iteration_square + 1)
-            node_anchor = np.array((np.maximum(node_tree_top_left[0], node_anchor[0]), np.minimum(node_tree_top_left[1], node_anchor[1]))) + np.array((node_pad[0] * 0.5, node_pad[1] * -0.5))
+            node_anchor = np.array((np.maximum(node_tree_top_left[0], node_anchor[0]), np.minimum(node_tree_top_left[1], node_anchor[1]))) + node_pad * (0.5, -0.5)
         def done_callback(future):
             nonlocal last_data_block
             nonlocal iteration

--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -92,13 +92,7 @@ class DreamTexture(bpy.types.Operator):
             )
 
         # Setup the progress indicator
-        def step_progress_update(self, context):
-            if hasattr(context.area, "regions"):
-                for region in context.area.regions:
-                    if region.type == "UI":
-                        region.tag_redraw()
-            return None
-        bpy.types.Scene.dream_textures_progress = bpy.props.IntProperty(name="", default=0, min=0, max=generated_args['steps'], update=step_progress_update)
+        bpy.types.Scene.dream_textures_progress = bpy.props.IntProperty(name="", default=0, min=0, max=generated_args['steps'])
         scene.dream_textures_info = "Starting..."
 
         last_data_block = None
@@ -109,6 +103,10 @@ class DreamTexture(bpy.types.Operator):
             if step_image.final:
                 return
             scene.dream_textures_progress = step_image.step
+            for area in context.screen.areas:
+                for region in area.regions:
+                    if region.type == "UI":
+                        region.tag_redraw()
             if len(step_image.images) > 0:
                 image = step_image.tile_images()
                 last_data_block = bpy_image(f"Step {step_image.step}/{generated_args['steps']}", image.shape[1], image.shape[0], image.ravel(), last_data_block)

--- a/operators/dream_texture.py
+++ b/operators/dream_texture.py
@@ -164,6 +164,8 @@ class DreamTexture(bpy.types.Operator):
                             setattr(history_entry, key, value)
                 history_entry.seed = str(seed)
                 history_entry.hash = image_hash
+                history_entry.width = result_image.shape[1]
+                history_entry.height = result_image.shape[0]
                 if is_file_batch:
                     history_entry.prompt_structure_token_subject = file_batch_lines[iteration]
                 iteration += 1

--- a/operators/upscale.py
+++ b/operators/upscale.py
@@ -24,6 +24,21 @@ def bpy_image(name, width, height, pixels, existing_image):
     image.update()
     return image
 
+def get_source_image(context):
+    node_tree = context.material.node_tree if hasattr(context, 'material') else None
+    active_node = next((node for node in node_tree.nodes if node.select and node.bl_idname == 'ShaderNodeTexImage'), None) if node_tree is not None else None
+    if active_node is not None and active_node.image is not None:
+        return active_node.image
+    elif context.area.type == 'IMAGE_EDITOR':
+        return context.area.spaces.active.image
+    else:
+        input_image = None
+        for area in context.screen.areas:
+            if area.type == 'IMAGE_EDITOR':
+                if area.spaces.active.image is not None:
+                    input_image = area.spaces.active.image
+        return input_image
+
 class Upscale(bpy.types.Operator):
     bl_idname = "shade.dream_textures_upscale"
     bl_label = "Upscale"
@@ -49,14 +64,7 @@ class Upscale(bpy.types.Operator):
 
         bpy.types.Scene.dream_textures_info = bpy.props.StringProperty(name="Info", update=step_progress_update)
 
-        input_image = None
-        if active_node is not None and active_node.image is not None:
-            input_image = active_node.image
-        else:
-            for area in context.screen.areas:
-                if area.type == 'IMAGE_EDITOR':
-                    if area.spaces.active.image is not None:
-                        input_image = area.spaces.active.image
+        input_image = get_source_image(context)
         if input_image is None:
             self.report({"ERROR"}, "No open image in the Image Editor space, or selected Image Texture node.")
             return {"FINISHED"}

--- a/operators/upscale.py
+++ b/operators/upscale.py
@@ -90,7 +90,7 @@ class Upscale(bpy.types.Operator):
             scene.dream_textures_progress = tile.tile
             last_data_block = bpy_image(f"Tile {tile.tile}/{tile.total}", tile.image.shape[1], tile.image.shape[0], tile.image.ravel(), last_data_block)
             for area in screen.areas:
-                if area.type == 'IMAGE_EDITOR':
+                if area.type == 'IMAGE_EDITOR' and not area.spaces.active.use_image_pin:
                     area.spaces.active.image = last_data_block
 
         def image_done(future):
@@ -103,7 +103,7 @@ class Upscale(bpy.types.Operator):
                 return
             image = bpy_image(f"{input_image.name} (Upscaled)", tile.image.shape[1], tile.image.shape[0], tile.image.ravel(), last_data_block)
             for area in screen.areas:
-                if area.type == 'IMAGE_EDITOR':
+                if area.type == 'IMAGE_EDITOR' and not area.spaces.active.use_image_pin:
                     area.spaces.active.image = image
             if active_node is not None:
                 active_node.image = image

--- a/ui/panels/dream_texture.py
+++ b/ui/panels/dream_texture.py
@@ -358,6 +358,8 @@ def actions_panel(sub_panel, space_type, get_prompt):
             
             row = layout.row()
             row.scale_y = 1.5
+            if CancelGenerator.poll(context):
+                row.operator(CancelGenerator.bl_idname, icon="SNAP_FACE", text="")
             if context.scene.dream_textures_progress <= 0:
                 if context.scene.dream_textures_info != "":
                     row.label(text=context.scene.dream_textures_info, icon="INFO")
@@ -368,8 +370,6 @@ def actions_panel(sub_panel, space_type, get_prompt):
                 disabled_row.use_property_split = True
                 disabled_row.prop(context.scene, 'dream_textures_progress', slider=True)
                 disabled_row.enabled = False
-            if CancelGenerator.poll(context):
-                row.operator(CancelGenerator.bl_idname, icon="CANCEL", text="")
             row.operator(ReleaseGenerator.bl_idname, icon="X", text="")
 
             if context.scene.dream_textures_last_execution_time != "":

--- a/ui/panels/dream_texture.py
+++ b/ui/panels/dream_texture.py
@@ -9,7 +9,7 @@ from ...absolute_path import CLIPSEG_WEIGHTS_PATH
 from ..presets import DREAM_PT_AdvancedPresets
 from ...pil_to_image import *
 from ...prompt_engineering import *
-from ...operators.dream_texture import DreamTexture, ReleaseGenerator, CancelGenerator
+from ...operators.dream_texture import DreamTexture, ReleaseGenerator, CancelGenerator, get_source_image
 from ...operators.open_latest_version import OpenLatestVersion, is_force_show_download, new_version_available
 from ...operators.view_history import ImportPromptFile
 from ..space_types import SPACE_TYPES
@@ -63,14 +63,7 @@ def dream_texture_panels():
         def get_seamless_result(context, prompt):
             init_image = None
             if prompt.use_init_img and prompt.init_img_action in ['modify', 'inpaint']:
-                match prompt.init_img_src:
-                    case 'file':
-                        init_image = context.scene.init_img
-                    case 'open_editor':
-                        for area in context.screen.areas:
-                            if area.type == 'IMAGE_EDITOR':
-                                if area.spaces.active.image is not None:
-                                    init_image = area.spaces.active.image
+                init_image = get_source_image(context, prompt.init_img_src)
             context.scene.seamless_result.check(init_image)
             return context.scene.seamless_result
 

--- a/ui/panels/upscaling.py
+++ b/ui/panels/upscaling.py
@@ -1,7 +1,7 @@
 from bpy.types import Panel
 from ...pil_to_image import *
 from ...prompt_engineering import *
-from ...operators.upscale import Upscale
+from ...operators.upscale import Upscale, get_source_image
 from ...operators.dream_texture import CancelGenerator, ReleaseGenerator
 from ...generator_process.actions.detect_seamless import SeamlessAxes
 from ...generator_process.actions.prompt_to_image import Pipeline
@@ -44,14 +44,7 @@ def upscaling_panels():
                 if prompt.seamless_axes == SeamlessAxes.AUTO:
                     node_tree = context.material.node_tree if hasattr(context, 'material') else None
                     active_node = next((node for node in node_tree.nodes if node.select and node.bl_idname == 'ShaderNodeTexImage'), None) if node_tree is not None else None
-                    init_image = None
-                    if active_node is not None and active_node.image is not None:
-                        init_image = active_node.image
-                    else:
-                        for area in context.screen.areas:
-                            if area.type == 'IMAGE_EDITOR':
-                                if area.spaces.active.image is not None:
-                                    init_image = area.spaces.active.image
+                    init_image = get_source_image(context)
                     context.scene.dream_textures_upscale_seamless_result.check(init_image)
                     auto_row = layout.row()
                     auto_row.enabled = False
@@ -87,10 +80,7 @@ def upscaling_panels():
                 layout.use_property_split = True
                 layout.use_property_decorate = False
                 
-                image = None
-                for area in context.screen.areas:
-                    if area.type == 'IMAGE_EDITOR':
-                        image = area.spaces.active.image
+                image = get_source_image(context)
                 row = layout.row()
                 row.scale_y = 1.5
                 if context.scene.dream_textures_progress <= 0:


### PR DESCRIPTION
- When there are multiple image editors, generating from an open image source or upscaling will now pick the image from the image editor it was executed from.
- Image editors with image pin activated will no longer be replaced with generated images.
- Cancel generator operator has been slightly changed to better differentiate it from release generator.
![blender_nFIlZtKP8q](https://user-images.githubusercontent.com/47096043/236645873-e79f3867-79ae-4057-9747-6413b9c5ce78.gif)
- Image texture nodes will now fill the shader editor view better instead of just the bottom right corner.
![blender_NpISzg732d](https://user-images.githubusercontent.com/47096043/236645879-56d6a80d-1e2b-44ca-b182-06c87c1b24b0.gif)
