### PR TITLE
Zip Dependencies with Long Paths

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -45,6 +45,9 @@ jobs:
         shell: bash
         run: 'python -m pip install -r requirements/win-linux-cuda.txt --no-cache-dir --target .python_dependencies'
         working-directory: dream_textures
+      - name: Zip dependencies with long paths
+        shell: bash
+        run: 'python ./dream_textures/scripts/zip_dependencies.py'
       - name: Archive Release
         uses: thedoctor0/zip-release@main
         with:
@@ -73,6 +76,9 @@ jobs:
         shell: bash
         run: 'python -m pip install -r requirements/win-dml.txt --no-cache-dir --target .python_dependencies'
         working-directory: dream_textures
+      - name: Zip dependencies with long paths
+        shell: bash
+        run: 'python ./dream_textures/scripts/zip_dependencies.py'
       - name: Archive Release
         uses: thedoctor0/zip-release@main
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 *.so
 
 # Distribution / packaging
+.python_dependencies.zip
 .Python
 build/
 develop-eggs/

--- a/scripts/zip_dependencies.py
+++ b/scripts/zip_dependencies.py
@@ -1,0 +1,26 @@
+import shutil
+import zipfile
+from pathlib import Path
+
+
+def main():
+    root = Path(__file__).parent.parent
+    deps = root / '.python_dependencies'
+    deps_to_zip = [deps / 'transformers']
+
+    for dep in deps_to_zip:
+        if not dep.exists():
+            raise FileNotFoundError(dep)
+        elif not dep.is_dir():
+            raise EnvironmentError(f"not a directory {dep}")
+
+    zip_deps_path = root / '.python_dependencies.zip'
+    zip_deps_path.unlink(True)
+    with zipfile.PyZipFile(str(zip_deps_path), mode='x') as zip_deps:
+        for dep in deps_to_zip:
+            zip_deps.writepy(str(dep))
+            shutil.rmtree(str(dep))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Currently Windows users struggle to install packaged releases due to errors caused by long paths, even when long paths are enabled for their system. Once installed a certain file has an entire path length of 259 characters when not including the Windows username. This became more of a noticeable issue in the last release due to a path in the transformers module growing by 11 characters.

To help prevent this issue, this PR zips the transformers module separately and enables it to be loaded like normal. Now the max path length is 225, so installing shouldn't be an issue as long as the username isn't more than 34 characters or another module grows in path length. This method is a little limiting as it only supports zipping modules that use .py files, no .dll or other special files. The new longest path belongs to torch, which is not compatible to shorten the path length further.