### PR TITLE
Only check for issues with 'bug' label

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,3 +21,4 @@ jobs:
           days-before-pr-stale: -1
           days-before-pr-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          only-labels: bug


### PR DESCRIPTION
This option should only run the stale bot on issues with the `bug` label. If any other labels are present, it will not mark the issue as stale.

The `confirmed` label, or a specifier label such as `AMD`, `NVIDIA`, `render pass`, can be used to disable the stale bot for an issue.