### PR TITLE
Update DirectML

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -24,8 +24,6 @@ jobs:
             filename_suffix: ''
           - python: '3.11'
             filename_suffix: '-4-1'
-        exclude:
-          - { platform: { requirements: win-dml.txt }, version: { python: '3.11' } }
     runs-on: ${{ matrix.platform.os }}
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Torch-DirectML has a new release with builds that now support python 3.11 and 3.12. A couple of the patches have been removed since they don't appear to be needed anymore, but there is one new bug that I've included a fix for.