### PR TITLE
Fix render pass image util to flatten array

### DIFF
--- a/image_utils.py
+++ b/image_utils.py
@@ -689,7 +689,10 @@ def np_to_render_pass(
         array = to_dtype(array, dtype)
     if top_to_bottom:
         array = np.flipud(array)
-    render_pass.rect.foreach_set(array.reshape(-1))
+    if BLENDER_VERSION >= (4, 1, 0):
+        render_pass.rect.foreach_set(array.reshape(-1))
+    else:
+        render_pass.rect.foreach_set(array.reshape(-1, render_pass.channels))
 
 
 def _mode(array, mode):

--- a/image_utils.py
+++ b/image_utils.py
@@ -689,7 +689,7 @@ def np_to_render_pass(
         array = to_dtype(array, dtype)
     if top_to_bottom:
         array = np.flipud(array)
-    render_pass.rect.foreach_set(array.reshape(-1, render_pass.channels))
+    render_pass.rect.foreach_set(array.reshape(-1))
 
 
 def _mode(array, mode):


### PR DESCRIPTION
This was failing before, as `foreach_set` is expecting a flat array instead of a 2D array of `(width * height, channels)`