### PR TITLE
Fix pylint warning `no-else-return`

### DIFF
--- a/api/models/generation_result.py
+++ b/api/models/generation_result.py
@@ -52,7 +52,7 @@ class GenerationResult:
         images = [result.image for result in results]
         if len(images) == 0:
             return None
-        elif len(images) == 1:
+        if len(images) == 1:
             return images[0]
         width = images[0].shape[1]
         height = images[0].shape[0]

--- a/engine/node_executor.py
+++ b/engine/node_executor.py
@@ -13,15 +13,13 @@ class NodeExecutionContext:
         self.preferences = bpy.context.preferences
     
     def _evaluate_input(self, input):
-        if input.is_linked:
-            if len(input.links) > 1:
-                return [
-                    self.execute(link.from_socket.node)[link.from_socket.name]
-                    for link in input.links
-                ]
-            else:
+            if input.is_linked:
+                if len(input.links) > 1:
+                    return [
+                        self.execute(link.from_socket.node)[link.from_socket.name]
+                        for link in input.links
+                    ]
                 return self.execute(input.links[0].from_socket.node)[input.links[0].from_socket.name]
-        else:
             return getattr(input, 'default_value', None)
 
     def execute(self, node):

--- a/generator_process/future.py
+++ b/generator_process/future.py
@@ -31,31 +31,29 @@ class Future:
         self.call_done_on_exception = True
 
     def result(self, last_only=False):
-        """
-        Get the result value (blocking).
-        """
-        def _response():
-            match len(self._responses):
-                case 0:
-                    return None
-                case 1:
-                    return self._responses[0]
-                case _:
-                    return self._responses[-1] if last_only else self._responses
-        if self._exception is not None:
-            raise self._exception
-        if self.done:
-            return _response()
-        else:
+            """
+            Get the result value (blocking).
+            """
+            def _response():
+                match len(self._responses):
+                    case 0:
+                        return None
+                    case 1:
+                        return self._responses[0]
+                    case _:
+                        return self._responses[-1] if last_only else self._responses
+            if self._exception is not None:
+                raise self._exception
+            if self.done:
+                return _response()
             self._done_event.wait()
             if self._exception is not None:
                 raise self._exception
             return _response()
     
     def exception(self):
-        if self.done:
-            return self._exception
-        else:
+            if self.done:
+                return self._exception
             self._done_event.wait()
             return self._exception
     

--- a/generator_process/models/optimizations.py
+++ b/generator_process/models/optimizations.py
@@ -42,10 +42,9 @@ class Optimizations:
         from ...absolute_path import absolute_path
         if sys.platform == "darwin":
             return "mps"
-        elif os.path.exists(absolute_path(".python_dependencies/torch_directml")):
+        if os.path.exists(absolute_path(".python_dependencies/torch_directml")):
             return "dml"
-        else:
-            return "cuda"
+        return "cuda"
 
     @classmethod
     def device_supports(cls, property, device) -> bool:

--- a/image_utils.py
+++ b/image_utils.py
@@ -165,13 +165,13 @@ def grayscale(array: NDArray) -> NDArray:
     if array.ndim == 3:
         if c in [1, 2]:
             return array[..., 0]
-        elif c in [3, 4]:
+        if c in [3, 4]:
             return np.max(array[..., :3], axis=-1)
         raise ValueError(f"Can't make {c} channels grayscale")
-    elif array.ndim == 4:
+    if array.ndim == 4:
         if c in [1, 2]:
             return array[..., :1]
-        elif c in [3, 4]:
+        if c in [3, 4]:
             return np.max(array[..., :3], axis=-1, keepdims=True)
         raise ValueError(f"Can't make {c} channels grayscale")
     raise ValueError(f"Can't make {array.ndim} dimensions grayscale")
@@ -242,9 +242,9 @@ def color_transform(array: NDArray, from_color_space: str, to_color_space: str, 
 
     if from_color_space == to_color_space:
         return array
-    elif from_color_space == "Linear" and to_color_space == "sRGB":
+    if from_color_space == "Linear" and to_color_space == "sRGB":
         return linear_to_srgb(array, clamp_srgb)
-    elif from_color_space == "sRGB" and to_color_space == "Linear":
+    if from_color_space == "sRGB" and to_color_space == "Linear":
         return srgb_to_linear(array)
 
     if not has_ocio:
@@ -264,7 +264,7 @@ def color_transform(array: NDArray, from_color_space: str, to_color_space: str, 
         if clamp_srgb and to_color_space == "sRGB":
             array = np.clip(array, 0, 1)
         return array
-    elif c in [2, 4]:
+    if c in [2, 4]:
         array = rgba(array)
         proc.applyRGBA(array)
         if clamp_srgb and to_color_space == "sRGB":
@@ -695,13 +695,13 @@ def np_to_render_pass(
 def _mode(array, mode):
     if mode is None:
         return array
-    elif mode == "RGBA":
+    if mode == "RGBA":
         return rgba(array)
-    elif mode == "RGB":
+    if mode == "RGB":
         return rgb(array)
-    elif mode == "L":
+    if mode == "L":
         return grayscale(array)
-    elif mode == "LA":
+    if mode == "LA":
         return ensure_alpha(_passthrough_alpha(array, grayscale(array)))
     raise ValueError(f"mode expected one of {['RGB', 'RGBA', 'L', 'LA', None]}, got {repr(mode)}")
 


### PR DESCRIPTION
### Changes Made:

- Applied automated fixes for the pylint warning `no-else-return`.
"Used in order to highlight an unnecessary block of code following an if containing a return statement. As such, it will warn when it encounters an else following a chain of ifs, all of them containing a return statement.. See [https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html](https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html)"

### Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.