### PR TITLE
Fix Blender 4.1 Render Pass

### DIFF
--- a/image_utils.py
+++ b/image_utils.py
@@ -652,7 +652,10 @@ def render_pass_to_np(
     top_to_bottom: bool = True
 ):
     array = np.empty((*reversed(size), render_pass.channels), dtype=np.float32)
-    render_pass.rect.foreach_get(array.reshape((-1, render_pass.channels)))
+    if BLENDER_VERSION >= (4, 1, 0):
+        render_pass.rect.foreach_get(array.reshape(-1))
+    else:
+        render_pass.rect.foreach_get(array.reshape(-1, render_pass.channels))
     if color_management:
         array = scene_color_transform(array, color_space=color_space, clamp_srgb=clamp_srgb)
     elif color_space is not None:

--- a/render_pass.py
+++ b/render_pass.py
@@ -56,9 +56,8 @@ def register_render_pass():
                                     for original_pass in original_layer.passes:
                                         if original_pass.name == render_pass.name:
                                             source_pass = original_pass
-                            pixels = np.empty((len(source_pass.rect), len(source_pass.rect[0])), dtype=np.float32)
-                            source_pass.rect.foreach_get(pixels)
-                            render_pass.rect[:] = pixels
+                            pixels = image_utils.render_pass_to_np(source_pass, size=(size_x, size_y))
+                            image_utils.np_to_render_pass(pixels, render_pass)
                 self.end_result(render_result)
             except Exception as e:
                 print(e)


### PR DESCRIPTION
Made a similar change in `image_utils.render_pass_to_np()` that was previously added to `image_utils.np_to_render_pass()` due to a change in Blender 4.1 no longer expecting a channel dimension when reading/writing to a render pass.